### PR TITLE
Fix: handle graphql-jit compilation failure

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const fp = require('fastify-plugin')
 const LRU = require('tiny-lru')
 const routes = require('./lib/routes')
 const { BadRequest, MethodNotAllowed } = require('http-errors')
-const { compileQuery } = require('graphql-jit')
+const { compileQuery, isCompiledQuery } = require('graphql-jit')
 const { Factory } = require('single-user-cache')
 const {
   parse,
@@ -421,7 +421,9 @@ const plugin = fp(async function (app, opts) {
 
     // minJit is 0 by default
     if (cached && cached.count++ === minJit) {
-      cached.jit = compileQuery(fastifyGraphQl.schema, document, operationName)
+      const execution = compileQuery(fastifyGraphQl.schema, document, operationName)
+      if (!isCompiledQuery(execution)) return maybeFormatErrors(execution, context)
+      cached.jit = execution
     }
 
     if (cached && cached.jit !== null) {


### PR DESCRIPTION
compileQuery() with graphql-jit may not suceed.
If it fails, the ExecultionResult is returned. 

https://github.com/zalando-incubator/graphql-jit/blob/50855a2540502ee78dd034bc55853c255a5500b5/src/execution.ts#L189