### PR TITLE
fix(validationErrors): call errorFormatter on validationErrors

### DIFF
--- a/index.js
+++ b/index.js
@@ -390,7 +390,7 @@ const plugin = fp(async function (app, opts) {
         }
         const err = new BadRequest()
         err.errors = validationErrors
-        return maybeFormatErrors(err, reply)
+        return maybeFormatErrors(err, context)
       }
 
       if (queryDepthLimit) {

--- a/index.js
+++ b/index.js
@@ -390,7 +390,7 @@ const plugin = fp(async function (app, opts) {
         }
         const err = new BadRequest()
         err.errors = validationErrors
-        throw err
+        return maybeFormatErrors(err, reply)
       }
 
       if (queryDepthLimit) {

--- a/test/gateway/pollingInterval.js
+++ b/test/gateway/pollingInterval.js
@@ -119,9 +119,7 @@ test('Polling schemas', async (t) => {
   t.deepEqual(JSON.parse(res2.body), {
     errors: [
       {
-        message:
-          'Cannot query field "lastName" on type "User". Did you mean "name"?',
-        locations: [{ line: 6, column: 13 }]
+        message: 'Cannot query field "lastName" on type "User". Did you mean "name"?'
       }
     ],
     data: null
@@ -361,9 +359,7 @@ test("Polling schemas (if service is down, schema shouldn't be changed)", async 
     t.deepEqual(JSON.parse(body), {
       errors: [
         {
-          message:
-            'Cannot query field "lastName" on type "User". Did you mean "name"?',
-          locations: [{ line: 6, column: 15 }]
+          message: 'Cannot query field "lastName" on type "User". Did you mean "name"?'
         }
       ],
       data: null
@@ -512,9 +508,7 @@ test('Polling schemas (if service is mandatory, exception should be thrown)', as
     t.deepEqual(JSON.parse(body), {
       errors: [
         {
-          message:
-            'Cannot query field "lastName" on type "User". Did you mean "name"?',
-          locations: [{ line: 6, column: 15 }]
+          message: 'Cannot query field "lastName" on type "User". Did you mean "name"?'
         }
       ],
       data: null
@@ -657,8 +651,7 @@ test('Polling schemas (cache should be cleared)', async (t) => {
   t.deepEqual(JSON.parse(res2.body), {
     errors: [
       {
-        message: 'Cannot query field "me" on type "Query". Did you mean "me2"?',
-        locations: [{ line: 3, column: 11 }]
+        message: 'Cannot query field "me" on type "Query". Did you mean "me2"?'
       }
     ],
     data: null

--- a/test/routes.js
+++ b/test/routes.js
@@ -1168,11 +1168,7 @@ test('Error handler set to true should not change default behavior', async (t) =
 
   const expectedResult = {
     errors: [{
-      message: 'Int cannot represent non-integer value: "2"',
-      locations: [{
-        line: 1,
-        column: 8
-      }]
+      message: 'Int cannot represent non-integer value: "2"'
     }],
     data: null
   }
@@ -1553,13 +1549,7 @@ test('cached errors', async (t) => {
   t.deepEqual(JSON.parse(get.body), {
     errors: [
       {
-        message: 'Cannot query field "test" on type "Query".',
-        locations: [
-          {
-            line: 1,
-            column: 9
-          }
-        ]
+        message: 'Cannot query field "test" on type "Query".'
       }
     ],
     data: null

--- a/test/validation-rules.js
+++ b/test/validation-rules.js
@@ -45,10 +45,11 @@ test('validationRules array - reports an error', async (t) => {
   await app.ready()
 
   try {
-    await app.graphql(query)
+    const response = await app.graphql(query)
+    t.equal(response.errors.length, 1)
+    t.equal(response.errors[0].message, 'Validation rule error')
   } catch (e) {
-    t.equal(e.errors.length, 1)
-    t.equal(e.errors[0].message, 'Validation rule error')
+    t.fail(e)
   }
 })
 
@@ -118,10 +119,11 @@ test('validationRules - reports an error', async (t) => {
   await app.ready()
 
   try {
-    await app.graphql(query)
+    const response = await app.graphql(query)
+    t.equal(response.errors.length, 1)
+    t.equal(response.errors[0].message, 'Validation rule error')
   } catch (e) {
-    t.equal(e.errors.length, 1)
-    t.equal(e.errors[0].message, 'Validation rule error')
+    t.fail(e)
   }
 })
 


### PR DESCRIPTION
This is reference on #252.

I don't sure if this is expected behavior, but when occurring a validation error we don't call `errorFormatter`. But, is it not the only path that could occur, on the `queryDepthLimit` is another example.

So, the question is:

We should continue to throw errors on `BadRequest` and not call the `errorFormatter` to user treat it on `errorHandler` or call `errorFormatter` for everything? The `errorHandler` on the second option is less called or never.