### PR TITLE
fix(gateway): should support multiple extends of the same type in the service SDL

### DIFF
--- a/lib/gateway/service-map.js
+++ b/lib/gateway/service-map.js
@@ -15,8 +15,8 @@ function hasDirective (directiveName, node) {
   return directives.some(directive => directive.name.value === directiveName)
 }
 
-function createFieldSet (definition, filterFn = () => false) {
-  const fieldsSet = new Set()
+function createFieldSet (existingSet, definition, filterFn = () => false) {
+  const fieldsSet = existingSet || new Set()
 
   if (definition.fields) {
     for (const field of definition.fields) {
@@ -39,11 +39,11 @@ function createTypeMap (schemaDefinition) {
     const isTypeExtensionByDirective = hasDirective('extends', definition)
     /* istanbul ignore else we are only interested in type definition and type extension scenarios */
     if (isTypeDefinitionNode(definition) && !isTypeExtensionByDirective) {
-      typeMap[definition.name.value] = createFieldSet(definition)
+      typeMap[definition.name.value] = createFieldSet(typeMap[definition.name.value], definition)
       types.add(definition.name.value)
     } else if (isTypeExtensionNode(definition) || isTypeExtensionByDirective) {
-      typeMap[definition.name.value] = createFieldSet(definition)
-      extensionTypeMap[definition.name.value] = createFieldSet(definition, hasDirective.bind(null, 'external'))
+      typeMap[definition.name.value] = createFieldSet(typeMap[definition.name.value], definition)
+      extensionTypeMap[definition.name.value] = createFieldSet(extensionTypeMap[definition.name.value], definition, hasDirective.bind(null, 'external'))
     }
   }
 

--- a/test/gateway/schema.js
+++ b/test/gateway/schema.js
@@ -838,7 +838,7 @@ test('Should support multiple `extends` of the same type in the service SDL', as
     },
     url: '/graphql',
     body: JSON.stringify({
-      query: `{ ping }`
+      query: '{ ping }'
     })
   })
 
@@ -855,7 +855,7 @@ test('Should support multiple `extends` of the same type in the service SDL', as
     },
     url: '/graphql',
     body: JSON.stringify({
-      query: `{ pong }`
+      query: '{ pong }'
     })
   })
 


### PR DESCRIPTION
The gateway can overwrite already defined types when calling `buildServiceMap`. 
I noticed the bug occurs if you define two Query returning a scalar.

I encountered this bug because I join the schema defined by multiple module before passing it to mercurius, so the service SDL contains multiple `extend Query`. Once the gateway schema is built the first `extend Query` doesn't have any resolver and skips the resolution to return `null` without forwarding the request to the related service.