### PR TITLE
Expose buildFederationSchema

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -308,6 +308,11 @@ declare namespace mercurius {
     execution: ExecutionResult,
     context: any
   ) => { statusCode: number, response: ExecutionResult };
+
+  /**
+   * Builds schema with support for federation mode.
+   */
+  const buildFederationSchema: (schema: string) => GraphQLSchema;
 }
 
 export default mercurius;

--- a/index.js
+++ b/index.js
@@ -473,5 +473,6 @@ const plugin = fp(async function (app, opts) {
 plugin.ErrorWithProps = ErrorWithProps
 plugin.defaultErrorFormatter = defaultErrorFormatter
 plugin.persistedQueryDefaults = persistedQueryDefaults
+plugin.buildFederationSchema = buildFederationSchema
 
 module.exports = plugin

--- a/test/federation.js
+++ b/test/federation.js
@@ -2,7 +2,8 @@
 
 const { test } = require('tap')
 const Fastify = require('fastify')
-const { printSchema } = require('graphql')
+const { printSchema, defaultFieldResolver } = require('graphql')
+const { MapperKind, mapSchema, getDirectives, makeExecutableSchema, printSchemaWithDirectives, getResolversFromSchema, mergeResolvers } = require('graphql-tools')
 const WebSocket = require('ws')
 const mq = require('mqemitter')
 const GQL = require('..')
@@ -126,6 +127,64 @@ test('federation support using schema from buildFederationSchema', async (t) => 
   query = 'mutation { add(a: 11 b: 19) }'
   res = await app.inject({ method: 'POST', url: '/graphql', body: { query } })
   t.deepEqual(JSON.parse(res.body), { data: { add: 30 } })
+})
+
+test('federation support using schema from buildFederationSchema and custom directives', async (t) => {
+  const app = Fastify()
+  const schema = `
+    directive @upper on FIELD_DEFINITION
+    
+    type Query {
+      foo: String @upper
+    }
+  `
+
+  const resolvers = {
+    Query: {
+      foo: () => 'bar'
+    }
+  }
+
+  function upperDirectiveTransformer (schema) {
+    return mapSchema(schema, {
+      [MapperKind.OBJECT_FIELD]: (fieldConfig) => {
+        const directives = getDirectives(schema, fieldConfig)
+        if (directives.upper) {
+          const { resolve = defaultFieldResolver } = fieldConfig
+          fieldConfig.resolve = async function (source, args, context, info) {
+            const result = await resolve(source, args, context, info)
+            if (typeof result === 'string') {
+              return result.toUpperCase()
+            }
+            return result
+          }
+          return fieldConfig
+        }
+      }
+    })
+  }
+
+  const federationSchema = buildFederationSchema(schema)
+
+  const executableSchema = makeExecutableSchema({
+    typeDefs: printSchemaWithDirectives(federationSchema),
+    resolvers: mergeResolvers([getResolversFromSchema(federationSchema), resolvers]),
+    schemaTransforms: [upperDirectiveTransformer]
+  })
+
+  app.register(GQL, {
+    schema: executableSchema
+  })
+
+  await app.ready()
+
+  let query = '{ _service { sdl } }'
+  let res = await app.inject({ method: 'GET', url: `/graphql?query=${query}` })
+  t.deepEqual(JSON.parse(res.body), { data: { _service: { sdl: schema } } })
+
+  query = 'query { foo }'
+  res = await app.inject({ method: 'POST', url: '/graphql', body: { query } })
+  t.deepEqual(JSON.parse(res.body), { data: { foo: 'BAR' } })
 })
 
 test('a normal schema can be run in federated mode', async (t) => {

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -140,6 +140,7 @@ makeGraphqlServer({ schema, resolvers, validationRules: [] })
 makeGraphqlServer({ schema, resolvers, validationRules: [customValidationRule] })
 makeGraphqlServer({ schema, resolvers, validationRules: ({ variables, operationName, source }: { source: string, variables?: Record<string, any>, operationName?: string }) => [customValidationRule] })
 makeGraphqlServer({ schema, errorFormatter: mercurius.defaultErrorFormatter })
+makeGraphqlServer({ schema: mercurius.buildFederationSchema(schema) })
 
 // Gateway mode
 


### PR DESCRIPTION
Addresses #300 

After digging into it a bit more, I realized that I already need the federated schema before calling `makeExecutableSchema` as described in the issue, due to having federation specific directives (like `@key` and `@external`) in the schema.

To support that use case, I'm exporting `buildFederationSchema` function that will allow me calling it to extend my schema with types, directives and resolvers needed to run in federation mode. I can then extend the federated schema with custom directives.