### PR TITLE
feat: defineResolvers should throw if field is not defined in schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -279,8 +279,10 @@ const plugin = fp(async function (app, opts) {
             }
           } else if (prop === '__resolveReference') {
             type.resolveReference = resolver[prop]
-          } else {
+          } else if (fields[prop]) {
             fields[prop].resolve = resolver[prop]
+          } else {
+            throw new Error(`Cannot find field ${prop} of type ${type}`)
           }
         }
       } else if (type instanceof GraphQLScalarType || type instanceof GraphQLEnumType) {

--- a/test/app-decorator.js
+++ b/test/app-decorator.js
@@ -1107,18 +1107,11 @@ test('defineResolvers should throw if field is not defined in schema', async (t)
   app.register(GQL, { schema: schema })
 
   app.register(async function (app) {
-    app.graphql.defineResolvers(resolvers)
+    t.throws(function () {
+      app.graphql.defineResolvers(resolvers)
+    }, new Error('Cannot find field sub of type Query'))
   })
 
   // needed so that graphql is defined
   await app.ready()
-
-  const query = '{ add(x: 2, y: 2) }'
-  const res = await app.graphql(query)
-
-  t.deepEqual(res, {
-    data: {
-      add: 4
-    }
-  })
 })


### PR DESCRIPTION
`mercurius.defineResolvers` can fail to bind a resolver if it is not defined in the schema, this PR fails properly with the type and field name to help for debug