### PR TITLE
test(gateway): support array references and empty reponse

### DIFF
--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -107,12 +107,25 @@ function defineResolvers (schema, typeToServiceMap, serviceMap, typeFieldsToServ
             } else {
               // check if the field is default field of the type
               if (serviceMap[serviceForType].typeMap[type.name].has(fieldName)) {
-                field.resolve = makeResolver({
-                  service: serviceMap[serviceForFieldType],
-                  createOperation: createEntityReferenceResolverOperation,
-                  transformData: makeEntityTransformData(field),
-                  isReference: true
-                })
+                // Check if field is nullable
+                const isNonNull = field.astNode.type.kind === Kind.NON_NULL_TYPE
+                const leafKind = isNonNull ? field.astNode.type.type.kind : field.astNode.type.kind
+
+                if (leafKind === Kind.LIST_TYPE) {
+                  field.resolve = makeResolver({
+                    service: serviceMap[serviceForFieldType],
+                    createOperation: createEntityReferenceResolverOperation,
+                    transformData: response => response ? response.json.data._entities : (isNonNull ? [] : null),
+                    isReference: true
+                  })
+                } else {
+                  field.resolve = makeResolver({
+                    service: serviceMap[serviceForFieldType],
+                    createOperation: createEntityReferenceResolverOperation,
+                    transformData: response => response.json.data._entities[0],
+                    isReference: true
+                  })
+                }
               } else {
                 field.resolve = makeResolver({
                   service: serviceMap[serviceForFieldType],
@@ -141,25 +154,6 @@ function defineResolvers (schema, typeToServiceMap, serviceMap, typeFieldsToServ
         }
       }
     }
-  }
-}
-
-function makeEntityTransformData (field) {
-  const isNonNull = field.astNode.type.kind === Kind.NON_NULL_TYPE
-  const leafKind = isNonNull ? field.astNode.type.type.kind : field.astNode.type.kind
-
-  if (leafKind === Kind.LIST_TYPE) {
-    return function transformData (response) {
-      if (!response) {
-        return isNonNull ? [] : null
-      }
-
-      return response.json.data._entities
-    }
-  }
-
-  return function transformData (response) {
-    return response.json.data._entities[0]
   }
 }
 

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -110,9 +110,7 @@ function defineResolvers (schema, typeToServiceMap, serviceMap, typeFieldsToServ
                 field.resolve = makeResolver({
                   service: serviceMap[serviceForFieldType],
                   createOperation: createEntityReferenceResolverOperation,
-                  transformData: field.astNode.type.kind === Kind.LIST_TYPE
-                    ? response => response.json.data._entities
-                    : response => response.json.data._entities[0],
+                  transformData: makeEntityTransformData(field),
                   isReference: true
                 })
               } else {
@@ -143,6 +141,25 @@ function defineResolvers (schema, typeToServiceMap, serviceMap, typeFieldsToServ
         }
       }
     }
+  }
+}
+
+function makeEntityTransformData (field) {
+  const isNonNull = field.astNode.type.kind === Kind.NON_NULL_TYPE
+  const leafKind = isNonNull ? field.astNode.type.type.kind : field.astNode.type.kind
+
+  if (leafKind === Kind.LIST_TYPE) {
+    return function transformData (response) {
+      if (!response) {
+        return isNonNull ? [] : null
+      }
+
+      return response.json.data._entities
+    }
+  }
+
+  return function transformData (response) {
+    return response.json.data._entities[0]
   }
 }
 

--- a/test/gateway/schema.js
+++ b/test/gateway/schema.js
@@ -1045,7 +1045,7 @@ test('Should support array references with _entities query and empty response an
       id: ID!
       title: String
       content: String
-      authors: [User]!
+      authors: [User]
     }
 
     extend type User @key(fields: "id") {

--- a/test/gateway/schema.js
+++ b/test/gateway/schema.js
@@ -164,8 +164,6 @@ test('It builds the gateway schema correctly', async (t) => {
     }
   })
 
-  await gateway.listen(0)
-
   const query = `
   query MainQuery(
     $size: AvatarSize
@@ -361,8 +359,6 @@ test('It support variable inside nested arguments', async (t) => {
     }
   })
 
-  await gateway.listen(0)
-
   const query = `
   query MainQuery(
     $userId: ID!
@@ -495,8 +491,6 @@ test('Should not throw on nullable reference', async (t) => {
     }
   })
 
-  await gateway.listen(0)
-
   const query = `
   {
     topPosts{
@@ -601,8 +595,6 @@ test('Should handle InlineFragment', async (t) => {
       ]
     }
   })
-
-  await gateway.listen(0)
 
   const query = `
   {
@@ -737,8 +729,6 @@ test('Should support array references with _entities query', async (t) => {
     }
   })
 
-  await gateway.listen(0)
-
   const query = `
   {
     topPosts{
@@ -828,8 +818,6 @@ test('Should support multiple `extends` of the same type in the service SDL', as
       ]
     }
   })
-
-  await gateway.listen(0)
 
   const res = await gateway.inject({
     method: 'POST',
@@ -960,8 +948,6 @@ test('Should support array references with _entities query and empty response', 
       ]
     }
   })
-
-  await gateway.listen(0)
 
   const query = `
   {
@@ -1099,8 +1085,6 @@ test('Should support array references with _entities query and empty response an
       ]
     }
   })
-
-  await gateway.listen(0)
 
   const query = `
   {


### PR DESCRIPTION
An empty `_entities` response for `LIST_TYPE` currently produces the following error:  `Cannot read property 'json' of undefined`.