### PR TITLE
feat(gateway): add initHeaders option for services

### DIFF
--- a/README.md
+++ b/README.md
@@ -904,6 +904,7 @@ __mercurius__ supports the following options:
     * `service.name`: A unique name for the service. Required.
     * `service.url`: The url of the service endpoint. Required
     * `service.rewriteHeaders`: `Function` A function that gets the original headers as a parameter and returns an object containing values that should be added to the headers
+    * `service.initHeaders`: `Function` or `Object` An object or a function that returns the headers sent to the service for the initial _service SDL query.
     * `service.wsUrl`: The url of the websocket endpoint
     * `service.wsConnectionParams`: `Function` or `Object`
       * `wsConnectionParams.connectionInitPayload`: `Function` or `Object` An object or a function that returns the `connection_init` payload sent to the service.

--- a/lib/gateway/service-map.js
+++ b/lib/gateway/service-map.js
@@ -99,6 +99,13 @@ async function buildServiceMap (services) {
         }
       },
       async init () {
+        let headers
+        if (typeof initHeaders === 'function') {
+          headers = await initHeaders()
+        } else if (typeof initHeaders === 'object') {
+          headers = initHeaders
+        }
+
         const response = await serviceConfig.sendRequest({
           body: JSON.stringify({
             query: `
@@ -109,7 +116,7 @@ async function buildServiceMap (services) {
             }
             `
           }),
-          headers: initHeaders
+          headers
         })
 
         const {

--- a/lib/gateway/service-map.js
+++ b/lib/gateway/service-map.js
@@ -67,7 +67,7 @@ async function buildServiceMap (services) {
   const serviceMap = {}
 
   for (const service of services) {
-    const { name, mandatory = false, ...opts } = service
+    const { name, mandatory = false, initHeaders, ...opts } = service
     const { request, close } = buildRequest(opts)
     const url = new URL(opts.url)
 
@@ -108,7 +108,8 @@ async function buildServiceMap (services) {
               }
             }
             `
-          })
+          }),
+          headers: initHeaders
         })
 
         const {

--- a/test/gateway/schema.js
+++ b/test/gateway/schema.js
@@ -1127,3 +1127,52 @@ test('Should support array references with _entities query and empty response an
     }
   })
 })
+
+test('Gateway sends initHeaders with _service sdl query', async (t) => {
+  t.plan(1)
+  const service = Fastify()
+  t.tearDown(() => {
+    service.close()
+  })
+  service.register(GQL, {
+    schema: `
+      extend type Query {
+        hello: String
+      }
+    `,
+    resolvers: {
+      Query: {
+        hello: async () => {
+          return 'world'
+        }
+      }
+    },
+    federationMetadata: true
+  })
+  service.addHook('preHandler', async (req, reply) => {
+    t.equal(req.headers.authorization, 'ok')
+    if (!req.headers.authorization) throw new Error('Unauthorized')
+  })
+
+  await service.listen(0)
+
+  const gateway = Fastify()
+  t.tearDown(() => {
+    gateway.close()
+  })
+  gateway.register(GQL, {
+    gateway: {
+      services: [
+        {
+          name: 'svc',
+          url: `http://localhost:${service.server.address().port}/graphql`,
+          initHeaders: {
+            authorization: 'ok'
+          }
+        }
+      ]
+    }
+  })
+
+  await gateway.ready()
+})


### PR DESCRIPTION
This PR adds an option to set request headers for the _service SDL query from gateway to services, similar to connectionInitPayload.