### PR TITLE
feat(subscription): implement subscription filters

### DIFF
--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -4,7 +4,7 @@
 
 - [Subscriptions](#subscriptions)
   - [Subscription support (simple)](#subscription-support-simple)
-  - [Filtered subscription](#filtered-subscription)
+  - [Subscription filters](#subscription-filters)
   - [Build a custom GraphQL context object for subscriptions](#build-a-custom-graphql-context-object-for-subscriptions)
   - [Subscription support (with redis)](#subscription-support-with-redis)
 
@@ -77,7 +77,7 @@ app.register(mercurius, {
 })
 ```
 
-### Filtered subscription
+### Subscription filters
 
 
 ```js

--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -138,7 +138,7 @@ const resolvers = {
         (root, args, { pubsub }) => pubsub.subscribe('NOTIFICATION_ADDED'),
         (payload, { contains }) => {
           if (!contains) return true
-            return payload.notificationAdded.message.includes(contains)
+          return payload.notificationAdded.message.includes(contains)
         }
       )
   }

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ const queryDepth = require('./lib/queryDepth')
 const buildFederationSchema = require('./lib/federation')
 const buildGateway = require('./lib/gateway')
 const mq = require('mqemitter')
-const { PubSub } = require('./lib/subscriber')
+const { PubSub, withFilter } = require('./lib/subscriber')
 const { ErrorWithProps, defaultErrorFormatter } = require('./lib/errors')
 const persistedQueryDefaults = require('./lib/persistedQueryDefaults')
 
@@ -494,5 +494,6 @@ plugin.ErrorWithProps = ErrorWithProps
 plugin.defaultErrorFormatter = defaultErrorFormatter
 plugin.persistedQueryDefaults = persistedQueryDefaults
 plugin.buildFederationSchema = buildFederationSchema
+plugin.withFilter = withFilter
 
 module.exports = plugin

--- a/lib/subscriber.js
+++ b/lib/subscriber.js
@@ -84,6 +84,7 @@ function withFilter (subscribeFn, filterFn) {
           yield payload
         }
       } catch (err) {
+        context.app.log.error(err)
         continue
       }
     }

--- a/lib/subscriber.js
+++ b/lib/subscriber.js
@@ -75,7 +75,23 @@ class SubscriptionContext {
   }
 }
 
+function withFilter (subscribeFn, filterFn) {
+  return async function * (root, args, context, info) {
+    const subscription = await subscribeFn(root, args, context, info)
+    for await (const payload of subscription) {
+      try {
+        if (await filterFn(payload, args, context, info)) {
+          yield payload
+        }
+      } catch (err) {
+        continue
+      }
+    }
+  }
+}
+
 module.exports = {
   PubSub,
-  SubscriptionContext
+  SubscriptionContext,
+  withFilter
 }

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -21,7 +21,9 @@ function createConnectionHandler ({ schema, subscriber, fastify, onConnect, lruG
       return
     }
 
-    const context = {}
+    const context = {
+      app: fastify
+    }
     let resolveContext
 
     if (subscriptionContextFn) {

--- a/test/subscription.js
+++ b/test/subscription.js
@@ -1097,3 +1097,309 @@ test('subscription works properly if onConnect is not defined and connectionInit
     })
   })
 })
+
+test('subscription works with `withFilter` tool', t => {
+  t.plan(4)
+  const app = Fastify()
+  t.tearDown(() => app.close())
+
+  const { withFilter } = GQL
+
+  let idCount = 0
+  const notifications = []
+
+  const schema = `
+    type Notification {
+      id: ID!
+      message: String
+    }
+
+    type Query {
+      notifications: [Notification]
+    }
+
+    type Mutation {
+      addNotification(message: String!): Notification!
+    }
+
+    type Subscription {
+      notificationAdded(contains: String): Notification
+    }
+  `
+
+  const resolvers = {
+    Query: {
+      notifications: () => notifications
+    },
+    Mutation: {
+      addNotification: async (_, { message }, { pubsub }) => {
+        const id = idCount++
+        const notification = {
+          id,
+          message
+        }
+        notifications.push(notification)
+        await pubsub.publish({
+          topic: 'NOTIFICATION_ADDED',
+          payload: {
+            notificationAdded: notification
+          }
+        })
+      }
+    },
+    Subscription: {
+      notificationAdded: {
+        subscribe: withFilter(
+          (_, __, { pubsub }) => pubsub.subscribe('NOTIFICATION_ADDED'),
+          (payload, { contains }) => {
+            if (!contains) return true
+            return payload.notificationAdded.message.includes(contains)
+          }
+        )
+      }
+    }
+  }
+
+  app.register(GQL, {
+    schema,
+    resolvers,
+    subscription: true
+  })
+  app.listen(0, err => {
+    t.error(err)
+
+    const ws = new WebSocket('ws://localhost:' + (app.server.address()).port + '/graphql', 'graphql-ws')
+    const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8', objectMode: true })
+    t.tearDown(client.destroy.bind(client))
+    client.setEncoding('utf8')
+
+    client.write(JSON.stringify({
+      type: 'connection_init'
+    }))
+
+    client.write(JSON.stringify({
+      id: 1,
+      type: 'start',
+      payload: {
+        query: `
+            subscription {
+              notificationAdded(contains: "Hello") {
+                id
+                message
+              }
+            }
+          `
+      }
+    }))
+
+    client.write(JSON.stringify({
+      id: 2,
+      type: 'start',
+      payload: {
+        query: `
+            subscription {
+              notificationAdded {
+                id
+                message
+              }
+            }
+          `
+      }
+    }))
+
+    client.write(JSON.stringify({
+      id: 2,
+      type: 'stop'
+    }))
+
+    client.on('data', chunk => {
+      const data = JSON.parse(chunk)
+
+      if (data.id === 1 && data.type === 'data') {
+        t.true(!data.payload.data.notificationAdded.message.includes('filtered'))
+        client.end()
+      } else if (data.id === 2 && data.type === 'complete') {
+        app.inject({
+          method: 'POST',
+          url: '/graphql',
+          body: {
+            query: `
+              mutation {
+                addNotification(message: "filtered should not pass") {
+                  id
+                }
+              }
+            `
+          }
+        }, () => { t.pass() })
+        app.inject({
+          method: 'POST',
+          url: '/graphql',
+          body: {
+            query: `
+              mutation {
+                addNotification(message: "Hello World") {
+                  id
+                }
+              }
+            `
+          }
+        }, () => { t.pass() })
+      }
+    })
+  })
+})
+
+test('subscription handles `withFilter` if filter throws', t => {
+  t.plan(4)
+  const app = Fastify()
+  t.tearDown(() => app.close())
+
+  const { withFilter } = GQL
+
+  let idCount = 0
+  const notifications = []
+
+  const schema = `
+    type Notification {
+      id: ID!
+      message: String
+    }
+
+    type Query {
+      notifications: [Notification]
+    }
+
+    type Mutation {
+      addNotification(message: String!): Notification!
+    }
+
+    type Subscription {
+      notificationAdded(contains: String): Notification
+    }
+  `
+
+  const resolvers = {
+    Query: {
+      notifications: () => notifications
+    },
+    Mutation: {
+      addNotification: async (_, { message }, { pubsub }) => {
+        const id = idCount++
+        const notification = {
+          id,
+          message
+        }
+        notifications.push(notification)
+        await pubsub.publish({
+          topic: 'NOTIFICATION_ADDED',
+          payload: {
+            notificationAdded: notification
+          }
+        })
+      }
+    },
+    Subscription: {
+      notificationAdded: {
+        subscribe: withFilter(
+          (_, __, { pubsub }) => pubsub.subscribe('NOTIFICATION_ADDED'),
+          (payload, { contains }) => {
+            if (contains && !payload.notificationAdded.message.includes(contains)) {
+              throw new Error('fail')
+            }
+            return true
+          }
+        )
+      }
+    }
+  }
+
+  app.register(GQL, {
+    schema,
+    resolvers,
+    subscription: true
+  })
+  app.listen(0, err => {
+    t.error(err)
+
+    const ws = new WebSocket('ws://localhost:' + (app.server.address()).port + '/graphql', 'graphql-ws')
+    const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8', objectMode: true })
+    t.tearDown(client.destroy.bind(client))
+    client.setEncoding('utf8')
+
+    client.write(JSON.stringify({
+      type: 'connection_init'
+    }))
+
+    client.write(JSON.stringify({
+      id: 1,
+      type: 'start',
+      payload: {
+        query: `
+            subscription {
+              notificationAdded(contains: "Hello") {
+                id
+                message
+              }
+            }
+          `
+      }
+    }))
+
+    client.write(JSON.stringify({
+      id: 2,
+      type: 'start',
+      payload: {
+        query: `
+            subscription {
+              notificationAdded {
+                id
+                message
+              }
+            }
+          `
+      }
+    }))
+
+    client.write(JSON.stringify({
+      id: 2,
+      type: 'stop'
+    }))
+
+    client.on('data', chunk => {
+      const data = JSON.parse(chunk)
+
+      if (data.id === 1 && data.type === 'data') {
+        t.true(!data.payload.data.notificationAdded.message.includes('filtered'))
+        client.end()
+      } else if (data.id === 2 && data.type === 'complete') {
+        app.inject({
+          method: 'POST',
+          url: '/graphql',
+          body: {
+            query: `
+              mutation {
+                addNotification(message: "filtered should not pass") {
+                  id
+                }
+              }
+            `
+          }
+        }, () => { t.pass() })
+        app.inject({
+          method: 'POST',
+          url: '/graphql',
+          body: {
+            query: `
+              mutation {
+                addNotification(message: "Hello World") {
+                  id
+                }
+              }
+            `
+          }
+        }, () => { t.pass() })
+      }
+    })
+  })
+})


### PR DESCRIPTION
This PR adds an utility function for filtered subscriptions, inspired by apollo's [withFilter](https://www.apollographql.com/docs/apollo-server/data/subscriptions/#subscription-filters)