### PR TITLE
doc(README): add Federated subscriptions support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Features:
 - Just-In-Time compiler via [graphql-jit](http://npm.im/graphql-jit).
 - Subscriptions.
 - Federation support.
+- Federated subscriptions support.
 - Gateway implementation, including Subscriptions.
 - Batched query support.
 - Customisable persisted queries.


### PR DESCRIPTION
I think we should add this feature to the README, I don't know about any other graphql server that is capable of this feature for now.