### PR TITLE
doc(loaders): enhance loaders documentation

### DIFF
--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -9,7 +9,7 @@
   - [GET /playground](#get-playground)
 - [Decorators](#decorators)
   - [app.graphql(source, context, variables, operationName)](#appgraphqlsource-context-variables-operationname)
-  - [app.graphql.extendSchema(schema) and app.graphql.defineResolvers(resolvers)](#appgraphqlextendschemaschema-and-appgraphqldefineresolversresolvers)
+  - [app.graphql.extendSchema(schema), app.graphql.defineResolvers(resolvers) and app.graphql.defineLoaders(loaders)](#appgraphqlextendschemaschema-appgraphqldefineresolversresolvers-and-appgraphqldefineloadersloaders)
   - [app.graphql.replaceSchema(schema)](#appgraphqlreplaceschemaschema)
   - [app.graphql.schema](#appgraphqlschema)
   - [app.graphql.transformSchema(transforms)](#appgraphqltransformschematransforms)

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -75,7 +75,7 @@ app.listen(3000)
 
 ### Federation with \_\_resolveReference caching
 
-Just like standard resolvers, the `__resolveReference` resolver can be a performance bottleneck. To avoid this, the it is strongly recommended to define the `__resolveReference` function for an entity as a [loader](../#loaders).
+Just like standard resolvers, the `__resolveReference` resolver can be a performance bottleneck. To avoid this, the it is strongly recommended to define the `__resolveReference` function for an entity as a [loader](docs/loaders).
 
 ```js
 'use strict'

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -75,7 +75,7 @@ app.listen(3000)
 
 ### Federation with \_\_resolveReference caching
 
-Just like standard resolvers, the `__resolveReference` resolver can be a performance bottleneck. To avoid this, the it is strongly recommended to define the `__resolveReference` function for an entity as a [loader](#defineLoaders).
+Just like standard resolvers, the `__resolveReference` resolver can be a performance bottleneck. To avoid this, the it is strongly recommended to define the `__resolveReference` function for an entity as a [loader](../#loaders).
 
 ```js
 'use strict'

--- a/docs/loaders.md
+++ b/docs/loaders.md
@@ -1,0 +1,62 @@
+# mercurius
+
+## Loaders
+
+A loader is an utility to avoid the 1 + N query problem of GraphQL.
+Each defined loader will register a resolver that coalesces each of the
+request and combines them into a single, bulk query. Morever, it can
+also cache the results, so that other parts of the GraphQL do not have
+to fetch the same data.
+
+Each loader function has the signature `loader(queries, context)`.
+`queries` is an array of objects defined as `{ obj, params }` where
+`obj` is the current object and `params` are the GraphQL params (those
+are the first two parameters of a normal resolver). The `context` is the
+GraphQL context, and it includes a `reply` object.
+
+Example:
+
+```js
+const loaders = {
+  Dog: {
+    async owner(queries, { reply }) {
+      return queries.map(({ obj }) => owners[obj.name])
+    }
+  }
+}
+
+app.register(mercurius, {
+  schema,
+  resolvers,
+  loaders
+})
+```
+
+It is also possible disable caching with:
+
+```js
+const loaders = {
+  Dog: {
+    owner: {
+      async loader(queries, { reply }) {
+        return queries.map(({ obj }) => owners[obj.name])
+      },
+      opts: {
+        cache: false
+      }
+    }
+  }
+}
+
+app.register(mercurius, {
+  schema,
+  resolvers,
+  loaders
+})
+```
+
+Disabling caching has the advantage to avoid the serialization at
+the cost of more objects to fetch in the resolvers.
+
+Internally, it uses
+[single-user-cache](http://npm.im/single-user-cache).

--- a/docs/loaders.md
+++ b/docs/loaders.md
@@ -4,7 +4,7 @@
 
 A loader is an utility to avoid the 1 + N query problem of GraphQL.
 Each defined loader will register a resolver that coalesces each of the
-request and combines them into a single, bulk query. Morever, it can
+request and combines them into a single, bulk query. Moreover, it can
 also cache the results, so that other parts of the GraphQL do not have
 to fetch the same data.
 

--- a/docsify/sidebar.md
+++ b/docsify/sidebar.md
@@ -11,6 +11,7 @@
   * [Decorators](/docs/api/options#decorators)
   * [Error extensions](/docs/api/options#use-errors-extension-to-provide-additional-information-to-query-errors)
 * [Context](/docs/context)
+* [Loaders](/docs/loaders)
 * [Federation](/docs/federation)
 * [Subscriptions](/docs/subscriptions)
 * [Batched Queries](/docs/batched-queries)


### PR DESCRIPTION
I had difficulties finding loaders documentation in the new website, a search query leads to the federation documentation about the `__resolveReference` loader.
I think it deserves its own section in the sidebar.