### PR TITLE
improve types & docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Features:
 
 ## Install
 
-```
+```bash
 npm i fastify mercurius
 ```
 

--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -145,7 +145,7 @@ payload must conform to the following JSON schema:
 
 For code from [example](#example) use:
 
-```sh
+```bash
 curl -H "Content-Type:application/json" -XPOST -d '{"query": "query { add(x: 2, y: 2) }"}' http://localhost:3000/graphql
 ```
 
@@ -156,7 +156,7 @@ payload contains the GraphQL query.
 
 For code from [example](#example) use:
 
-```sh
+```bash
 curl -H "Content-Type:application/graphql" -XPOST -d "query { add(x: 2, y: 2) }" http://localhost:3000/graphql
 ```
 

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -5,7 +5,7 @@
 - [Use GraphQL server as a Gateway for federated schemas](#use-graphql-server-as-a-gateway-for-federated-schemas)
   - [Periodically refresh federated schemas in Gateway mode](#periodically-refresh-federated-schemas-in-gateway-mode)
   - [Programmatically refresh federated schemas in Gateway mode](#programmatically-refresh-federated-schemas-in-gateway-mode)
-  - [Flag a service as mandatory in Gateway mode](#flag-a-service-as-mandatory-in-gateway-mode)
+  - [Flag service as mandatory in Gateway mode](#flag-service-as-mandatory-in-gateway-mode)
   - [Using a custom errorHandler for handling downstream service errors in Gateway mode](#using-a-custom-errorhandler-for-handling-downstream-service-errors-in-gateway-mode)
 
 ## Federation

--- a/docs/integrations/mercurius-integration-testing.md
+++ b/docs/integrations/mercurius-integration-testing.md
@@ -6,7 +6,7 @@ You can easily test your GraphQL API using `mercurius-integration-testing`.
 
 ## Installation
 
-```sh
+```bash
 npm install mercurius-integration-testing
 ```
 

--- a/docs/integrations/nexus-schema.md
+++ b/docs/integrations/nexus-schema.md
@@ -5,7 +5,7 @@ This allows you to follow a code first approach instead of the SDL first.
 
 ## Installation
 
-```sh
+```bash
 npm install --save @nexus/schema
 ```
 
@@ -73,6 +73,6 @@ app.listen(3000);
 
 If you run this, you will get type definitions and a generated GraphQL based on your code:
 
-```sh
+```bash
 node index.js
 ```

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -12,7 +12,7 @@ Check [https://github.com/mercurius-js/mercurius-upload](https://github.com/merc
 
 [**Altair**](https://altair.sirmuel.design/) plugin. Fully featured GraphQL Client IDE, good alternative of `graphiql` and `graphql-playground`.
 
-```sh
+```bash
 npm install altair-fastify-plugin
 ```
 

--- a/index.html
+++ b/index.html
@@ -57,5 +57,7 @@
     <script src="//cdn.jsdelivr.net/npm/docsify/lib/docsify.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/docsify-copy-code"></script>
+    <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-bash.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-typescript.min.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Docs
- Added `bash` & `typescript` [language-lighting](https://docsify.js.org/#/language-highlight)
- Renamed `sh` tags to `bash` due to `Prism` not recognizing them properly
- Fix TOC reference in Federation docs

## Types

- Added `PubSub` to context & `app.graphql.pubsub`
- Improved Context types & allowing [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation)
- Added `app.graphql()` function signature
- Improved Loaders types
- Added `app.graphql.transformSchema(schemaTransforms)`
- Improved `MercuriusGatewayService` types
- Fixed `PeristedQueryProvider` typo, while keeping the old name but deprecated, to prevent breaking change. _I am not completely sure if it's really necessary_
- Minor change in `IResolvers` to fix [GraphQL Codegen](https://graphql-code-generator.com/) compatibility.  
