### PR TITLE
feat(loaders): expose info field

### DIFF
--- a/index.js
+++ b/index.js
@@ -319,11 +319,11 @@ const plugin = fp(async function (app, opts) {
 
     function defineLoader (name) {
       // async needed because of throw
-      return async function (obj, params, { reply }) {
+      return async function (obj, params, { reply }, info) {
         if (!reply) {
           throw new Error('loaders only work via reply.graphql()')
         }
-        return reply[kLoaders][name]({ obj, params })
+        return reply[kLoaders][name]({ obj, params, info })
       }
     }
 

--- a/test/loaders.js
+++ b/test/loaders.js
@@ -64,23 +64,23 @@ test('loaders create batching resolvers', async (t) => {
   const loaders = {
     Dog: {
       async owner (queries, { reply }) {
+        const objs = queries.map(({ obj }) => obj)
+        const params = queries.map(({ params }) => params)
+
         // note that the second entry for max is cached
-        t.deepEqual(queries, [{
-          obj: {
-            name: 'Max'
-          },
-          params: {}
-        }, {
-          obj: {
-            name: 'Charlie'
-          },
-          params: {}
-        }, {
-          obj: {
-            name: 'Buddy'
-          },
-          params: {}
-        }])
+        t.deepEqual(objs, [
+          { name: 'Max' },
+          { name: 'Charlie' },
+          { name: 'Buddy' }
+        ])
+        t.deepEqual(params, [
+          { },
+          { },
+          { }
+        ])
+
+        queries.map(({ info }) => t.true(typeof info === 'object'))
+
         return queries.map(({ obj }) => owners[obj.name])
       }
     }
@@ -135,28 +135,25 @@ test('disable cache for each loader', async (t) => {
     Dog: {
       owner: {
         async loader (queries, { reply }) {
+          const objs = queries.map(({ obj }) => obj)
+          const params = queries.map(({ params }) => params)
+
           // note that the second entry for max is NOT cached
-          t.deepEqual(queries, [{
-            obj: {
-              name: 'Max'
-            },
-            params: {}
-          }, {
-            obj: {
-              name: 'Charlie'
-            },
-            params: {}
-          }, {
-            obj: {
-              name: 'Buddy'
-            },
-            params: {}
-          }, {
-            obj: {
-              name: 'Max'
-            },
-            params: {}
-          }])
+          t.deepEqual(objs, [
+            { name: 'Max' },
+            { name: 'Charlie' },
+            { name: 'Buddy' },
+            { name: 'Max' }
+          ])
+          t.deepEqual(params, [
+            {},
+            {},
+            {},
+            {}
+          ])
+
+          queries.map(({ info }) => t.true(typeof info === 'object'))
+
           return queries.map(({ obj }) => owners[obj.name])
         },
         opts: {
@@ -475,23 +472,22 @@ test('loaders support custom context', async (t) => {
     Dog: {
       async owner (queries, { reply, test }) {
         t.is(test, 'custom')
-        // note that the second entry for max is cached
-        t.deepEqual(queries, [{
-          obj: {
-            name: 'Max'
-          },
-          params: {}
-        }, {
-          obj: {
-            name: 'Charlie'
-          },
-          params: {}
-        }, {
-          obj: {
-            name: 'Buddy'
-          },
-          params: {}
-        }])
+        const objs = queries.map(({ obj }) => obj)
+        const params = queries.map(({ params }) => params)
+
+        // note that the second entry for max is NOT cached
+        t.deepEqual(objs, [
+          { name: 'Max' },
+          { name: 'Charlie' },
+          { name: 'Buddy' }
+        ])
+        t.deepEqual(params, [
+          {},
+          {},
+          {}
+        ])
+
+        queries.map(({ info }) => t.true(typeof info === 'object'))
         return queries.map(({ obj }) => owners[obj.name])
       }
     }


### PR DESCRIPTION
This PR tries to expose the info field to the loader function. This is currently not working because it broke the caching strategy. 

@mcollina could we have a way to ignore the info key in `single-user-cache` ?

Use case: I want to access the info field of each query in my loader to find the minimal merged projection required for this batch (i.e.   `const projection = extend(true, {}, ...queries.map(({ info }) => introspectFields(info)))` )