### PR TITLE
Fix refreshing subscription schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -209,7 +209,6 @@ const plugin = fp(async function (app, opts) {
       context: opts.context,
       persistedQueryProvider: opts.persistedQueryProvider,
       allowBatchedQueries: opts.allowBatchedQueries,
-      schema: fastifyGraphQl.schema,
       subscriber,
       verifyClient,
       onConnect,

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -246,7 +246,6 @@ module.exports = async function (app, opts) {
   if (subscriber) {
     app.register(subscription, {
       getOptions,
-      schema: opts.schema,
       subscriber,
       verifyClient,
       onConnect,

--- a/lib/subscription-connection.js
+++ b/lib/subscription-connection.js
@@ -18,7 +18,6 @@ const {
 
 module.exports = class SubscriptionConnection {
   constructor (socket, {
-    schema,
     subscriber,
     fastify,
     lruGatewayResolvers,
@@ -29,7 +28,6 @@ module.exports = class SubscriptionConnection {
   }) {
     this.fastify = fastify
     this.socket = socket
-    this.schema = schema
     this.lruGatewayResolvers = lruGatewayResolvers
     this.entityResolvers = entityResolvers
     this.subscriber = subscriber
@@ -166,9 +164,10 @@ module.exports = class SubscriptionConnection {
     this.subscriptionContexts.set(id, sc)
 
     const document = typeof query !== 'string' ? query : parse(query)
+    const schema = this.fastify ? this.fastify.graphql.schema : undefined
 
     const result = await subscribe(
-      this.schema,
+      schema,
       document,
       {}, // rootValue
       {

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -8,7 +8,7 @@ function handle (conn) {
   conn.end(JSON.stringify({ error: 'unknown route' }))
 }
 
-function createConnectionHandler ({ schema, subscriber, fastify, onConnect, lruGatewayResolvers, entityResolversFactory, subscriptionContextFn }) {
+function createConnectionHandler ({ subscriber, fastify, onConnect, lruGatewayResolvers, entityResolversFactory, subscriptionContextFn }) {
   return async (connection, request) => {
     const { socket } = connection
     if (socket.protocol === undefined ||
@@ -31,7 +31,6 @@ function createConnectionHandler ({ schema, subscriber, fastify, onConnect, lruG
     }
 
     const subscriptionConnection = new SubscriptionConnection(socket, {
-      schema,
       subscriber,
       fastify,
       onConnect,
@@ -52,7 +51,7 @@ function createConnectionHandler ({ schema, subscriber, fastify, onConnect, lruG
 }
 
 module.exports = function (fastify, opts, next) {
-  const { getOptions, schema, subscriber, verifyClient, onConnect, lruGatewayResolvers, entityResolversFactory, subscriptionContextFn } = opts
+  const { getOptions, subscriber, verifyClient, onConnect, lruGatewayResolvers, entityResolversFactory, subscriptionContextFn } = opts
   fastify.register(fastifyWebsocket, {
     handle,
     options: {
@@ -64,7 +63,6 @@ module.exports = function (fastify, opts, next) {
   fastify.route({
     ...getOptions,
     wsHandler: createConnectionHandler({
-      schema,
       subscriber,
       fastify,
       onConnect,

--- a/test/gateway/pollingInterval.js
+++ b/test/gateway/pollingInterval.js
@@ -969,7 +969,8 @@ test('Polling schemas (subscriptions should be handled)', async (t) => {
 
     t.deepEqual(updatedUser, {
       id: 'u1',
-      name: 'John'
+      name: 'John',
+      lastName: 'Doe'
     })
   }
 


### PR DESCRIPTION
I noticed the subscription schema was never being refreshed because of how the schema was passed down to `subscription-connection`. After switching the schema usage to `fastify.schema` the schema correctly refreshes as expected.

There was an existing test that should have covered it, however, there was a mistake in the test itself. So adding additional tests seemed unnecessary.