### PR TITLE
feat: opentelemetry integration

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -4,3 +4,4 @@
 
 - [@nexus/schema](/docs/integrations/nexus-schema.md) - Declarative, code-first and strongly typed GraphQL schema construction for TypeScript & JavaScript
 - [mercurius-integration-testing](/docs/integrations/mercurius-integration-testing.md) - Utility library for writing mercurius integration tests.
+- [@opentelemetry](/docs/integrations/open-telemetry) - A framework for collecting traces and metrics from applications.

--- a/docs/integrations/open-telemetry.md
+++ b/docs/integrations/open-telemetry.md
@@ -4,6 +4,9 @@
 
 Mercurius is compatible with open-telemetry
 
+
+## Example
+
 Here is a simple exemple on how to enable tracing on Mercurius with OpenTelemetry:
 
 tracer.js

--- a/docs/integrations/open-telemetry.md
+++ b/docs/integrations/open-telemetry.md
@@ -60,7 +60,7 @@ const opentelemetry = require('@autotelic/fastify-opentelemetry')
 service.register(opentelemetry, { serviceName })
 service.register(mercurius, {
   schema: `
-  type Query {
+  extend type Query {
     add(x: Float, y: Float): Float
   }
   `,

--- a/docs/integrations/open-telemetry.md
+++ b/docs/integrations/open-telemetry.md
@@ -97,4 +97,4 @@ Start a zipkin service:
 $ docker run -d -p 9411:9411 openzipkin/zipkin
 ```
 
-You can know browser through mercurius tracing at `http://localhost:9411`
+You can know browse through mercurius tracing at `http://localhost:9411`

--- a/docs/integrations/open-telemetry.md
+++ b/docs/integrations/open-telemetry.md
@@ -97,4 +97,4 @@ Start a zipkin service:
 $ docker run -d -p 9411:9411 openzipkin/zipkin
 ```
 
-You can know browse through mercurius tracing at `http://localhost:9411`
+You can now browse through mercurius tracing at `http://localhost:9411`

--- a/docs/open-telemetry.md
+++ b/docs/open-telemetry.md
@@ -1,0 +1,89 @@
+# mercurius
+
+## OpenTelemetry (Tracing)
+
+Mercurius is fully compatible with open-telemetry
+
+Here is a simple exemple on how to enable tracing on Mercurius with OpenTelemetry and Zipkin:
+
+tracer.js
+```js
+'use strict'
+
+const api = require('@opentelemetry/api')
+const { NodeTracerProvider } = require('@opentelemetry/node')
+const { SimpleSpanProcessor } = require('@opentelemetry/tracing')
+const { ZipkinExporter } = require('@opentelemetry/exporter-zipkin')
+const { GraphQLInstrumentation } = require('@opentelemetry/instrumentation-graphql')
+
+module.exports = serviceName => {
+  const provider = new NodeTracerProvider()
+  const graphQLInstrumentation = new GraphQLInstrumentation()
+  graphQLInstrumentation.setTracerProvider(provider)
+  graphQLInstrumentation.enable()
+  provider.addSpanProcessor(
+    new SimpleSpanProcessor(
+      new ZipkinExporter({
+        serviceName
+      })
+    )
+  )
+  provider.register()
+  return api.trace.getTracer(serviceName)
+}
+```
+
+gateway.js
+```js
+const gateway = require('fastify')()
+const mercurius = require('mercurius')
+const opentelemetry = require('fastify-opentelemetry')
+
+const tracer = require('./tracer')('gateway')
+gateway.register(opentelemetry, tracer)
+gateway.register(mercurius, {
+  gateway: {
+    services: [
+      {
+        name: 'add',
+        url: 'http://localhost:4001/graphql'
+      }
+    ]
+  }
+})
+
+await gateway.listen(3000)
+```
+
+serviceAdd.js
+```js
+const service = require('fastify')()
+const mercurius = require('mercurius')
+const opentelemetry = require('fastify-opentelemetry')
+
+const tracer = require('./tracer')('service-add')
+service.register(opentelemetry, tracer)
+service.register(mercurius, {
+  schema: `
+  extend type Query {
+    add(x: Float, y: Float): Float
+  }
+  `,
+  resolvers: {
+    Query: {
+      add: (_, { x, y }) => x+y
+    }
+  },
+  federationMedata: true
+})
+
+await service.listen(4001)
+```
+
+Start a zipkin service:
+
+```
+$ docker run -d -p 9411:9411 openzipkin/zipkin
+```
+
+You can know browser through mercurius tracing at `http://localhost:9411`

--- a/docsify/sidebar.md
+++ b/docsify/sidebar.md
@@ -19,6 +19,7 @@
 * [Integrations](/docs/integrations/)
   * [@nexus/schema](/docs/integrations/nexus-schema)
   * [Testing](/docs/integrations/mercurius-integration-testing)
+  * [Tracing - OpenTelemetry](/docs/open-telemetry)
 * [Related plugins](/docs/plugins)
   * [mercurius-upload](/docs/plugins#mercurius-upload)
   * [altair-fastify-plugin](/docs/plugins#altair-fastify-plugin)

--- a/docsify/sidebar.md
+++ b/docsify/sidebar.md
@@ -19,7 +19,7 @@
 * [Integrations](/docs/integrations/)
   * [@nexus/schema](/docs/integrations/nexus-schema)
   * [Testing](/docs/integrations/mercurius-integration-testing)
-  * [Tracing - OpenTelemetry](/docs/open-telemetry)
+  * [Tracing - OpenTelemetry](/docs/integrations/open-telemetry)
 * [Related plugins](/docs/plugins)
   * [mercurius-upload](/docs/plugins#mercurius-upload)
   * [altair-fastify-plugin](/docs/plugins#altair-fastify-plugin)

--- a/lib/tracer.js
+++ b/lib/tracer.js
@@ -1,0 +1,5 @@
+'use strict'
+const api = require('@opentelemetry/api')
+const meta = require('../package.json')
+
+module.exports = api.trace.getTracer(meta.name, meta.version)

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@graphql-tools/merge": "^6.2.4",
     "@graphql-tools/schema": "^6.2.4",
     "@graphql-tools/utils": "^6.2.4",
+    "@opentelemetry/api": "0.11.0",
     "@sinonjs/fake-timers": "^6.0.1",
     "@types/node": "^14.0.23",
     "@types/ws": "^7.2.6",


### PR DESCRIPTION
Mercurius works with existing tools like `@autotelic/fastify-opentelemetry` and `@opentelemetry/instrumentation-graphql`. But it's missing some mercurius specific spans and attributes that we can add with the opentelemetry API.

As a reference, here is an example of a mercurius trace with a gateway and a service and without any additional opentelemetry integration:
![image](https://user-images.githubusercontent.com/1575833/98814948-b6d98d00-2426-11eb-8e54-01f95a224fc4.png)


And here is an example with a simple mercurius - graphql span added to the main fastifyGraphql function and a cached attribute (see PR changes):
![image](https://user-images.githubusercontent.com/1575833/98817154-0077a700-242a-11eb-8cb6-4aa20a5e6741.png)
 


We need to define what we want to expose in opentelemetry traces (spans and attributes). And maybe add a `telemetry` option to mercurius so user can enable/disable telemetry ?