### PR TITLE
fix(extendSchema): throw if federationMetadata is enabled

### DIFF
--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -310,6 +310,8 @@ async function run() {
 run()
 ```
 
+Note: `app.graphql.extendSchema` is not allowed if `federationMetadata` is enabled.
+
 #### app.graphql.replaceSchema(schema)
 
 It is possible to replace schema and resolvers using `makeSchemaExecutable` function in separate fastify plugins, like so:

--- a/index.js
+++ b/index.js
@@ -35,7 +35,8 @@ const {
   MER_ERR_GQL_GATEWAY,
   MER_ERR_GQL_VALIDATION,
   MER_ERR_INVALID_OPTS,
-  MER_ERR_METHOD_NOT_ALLOWED
+  MER_ERR_METHOD_NOT_ALLOWED,
+  MER_ERR_INVALID_METHOD
 } = require('./lib/errors')
 
 const kLoaders = Symbol('mercurius.loaders')
@@ -253,6 +254,9 @@ const plugin = fp(async function (app, opts) {
   fastifyGraphQl.extendSchema = function (s) {
     if (gateway) {
       throw new MER_ERR_GQL_GATEWAY('Calling extendSchema method when plugin is running in gateway mode is not allowed')
+    }
+    if (opts.federationMetadata) {
+      throw new MER_ERR_INVALID_METHOD('Calling extendSchema method when federationMetadata is enabled is not allowed')
     }
 
     if (typeof s === 'string') {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -101,6 +101,10 @@ const errors = {
     'MER_ERR_INVALID_OPTS',
     'Invalid options: %s'
   ),
+  MER_ERR_INVALID_METHOD: createError(
+    'MER_ERR_INVALID_METHOD',
+    'Invalid method: %s'
+  ),
   MER_ERR_METHOD_NOT_ALLOWED: createError(
     'MER_ERR_METHOD_NOT_ALLOWED',
     'Method not allowed',

--- a/test/app-decorator.js
+++ b/test/app-decorator.js
@@ -1115,3 +1115,35 @@ test('defineResolvers should throw if field is not defined in schema', async (t)
   // needed so that graphql is defined
   await app.ready()
 })
+
+test('calling extendSchema throws an error if federationMetadata is enabled', async (t) => {
+  const service = Fastify()
+  t.tearDown(() => {
+    service.close()
+  })
+  service.register(GQL, {
+    schema: `
+      extend type Query {
+        me: User
+      }
+
+      type User @key(fields: "id") {
+        id: ID!
+        name: String!
+      }
+    `,
+    federationMetadata: true
+  })
+  await service.ready()
+
+  try {
+    service.graphql.extendSchema(`
+      extend type Query {
+        field: String!
+      }
+    `)
+  } catch (err) {
+    t.is(err.message, 'Invalid method: Calling extendSchema method when federationMetadata is enabled is not allowed')
+    t.end()
+  }
+})

--- a/test/gateway/methods.js
+++ b/test/gateway/methods.js
@@ -136,35 +136,3 @@ test('calling extendSchema throws an error in gateway mode', async (t) => {
     t.end()
   }
 })
-
-test('calling extendSchema throws an error if federationMetadata is enabled', async (t) => {
-  const service = Fastify()
-  t.tearDown(() => {
-    service.close()
-  })
-  service.register(GQL, {
-    schema: `
-      extend type Query {
-        me: User
-      }
-
-      type User @key(fields: "id") {
-        id: ID!
-        name: String!
-      }
-    `,
-    federationMetadata: true
-  })
-  await service.ready()
-
-  try {
-    service.graphql.extendSchema(`
-      extend type Query {
-        field: String!
-      }
-    `)
-  } catch (err) {
-    t.is(err.message, 'Invalid method: Calling extendSchema method when federationMetadata is enabled is not allowed')
-    t.end()
-  }
-})

--- a/test/gateway/methods.js
+++ b/test/gateway/methods.js
@@ -136,3 +136,35 @@ test('calling extendSchema throws an error in gateway mode', async (t) => {
     t.end()
   }
 })
+
+test('calling extendSchema throws an error if federationMetadata is enabled', async (t) => {
+  const service = Fastify()
+  t.tearDown(() => {
+    service.close()
+  })
+  service.register(GQL, {
+    schema: `
+      extend type Query {
+        me: User
+      }
+
+      type User @key(fields: "id") {
+        id: ID!
+        name: String!
+      }
+    `,
+    federationMetadata: true
+  })
+  await service.ready()
+
+  try {
+    service.graphql.extendSchema(`
+      extend type Query {
+        field: String!
+      }
+    `)
+  } catch (err) {
+    t.is(err.message, 'Invalid method: Calling extendSchema method when federationMetadata is enabled is not allowed')
+    t.end()
+  }
+})


### PR DESCRIPTION
1 step to address the issue #348 

This PR prevent the usage of `extendSchema` if `federationMedata` is enabled