### PR TITLE
Add support for passing custom pubsub

### DIFF
--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -50,7 +50,8 @@
 - `queryDepth`: `Integer`. The maximum depth allowed for a single query. _Note: GraphiQL IDE (or Playground IDE) sends an introspection query when it starts up. This query has a depth of 7 so when the `queryDepth` value is smaller than 7 this query will fail with a `Bad Request` error_
 - `validationRules`: `Function` or `Function[]`. Optional additional validation rules that the queries must satisfy in addition to those defined by the GraphQL specification. When using `Function`, arguments include additional data from graphql request and the return value must be validation rules `Function[]`.
 - `subscription`: Boolean | Object. Enable subscriptions. It uses [mqemitter](https://github.com/mcollina/mqemitter) when it is true and exposes the pubsub interface to `app.graphql.pubsub`. To use a custom emitter set the value to an object containing the emitter.
-  - `subscription.emitter`: Custom emitter
+  - `subscription.emitter`: Custom emitter.
+  - `subscription.pubsub`: Custom pubsub, see [Subscriptions with custom PubSub](/docs/subscriptions.md#subscriptions-with-custom-pubsub) for more details. Note that when passing both `emitter` and `pubsub` options, `emitter` will be ignored.
   - `subscription.verifyClient`: `Function` A function which can be used to validate incoming connections.
   - `subscription.context`: `Function` Result of function is passed to subscription resolvers as a custom GraphQL context. The function receives the `connection` and `request` as parameters.
   - `subscription.onConnect`: `Function` A function which can be used to validate the `connection_init` payload. If defined it should return a truthy value to authorize the connection. If it returns an object the subscription context will be extended with the returned object.

--- a/index.d.ts
+++ b/index.d.ts
@@ -245,6 +245,7 @@ export interface MercuriusCommonOptions {
     | boolean
     | {
         emitter?: object;
+        pubsub?: any; // FIXME: Technically this should be the PubSub type. But PubSub is now typed as SubscriptionContext.
         verifyClient?: (
           info: { origin: string; secure: boolean; req: IncomingMessage },
           next: (

--- a/index.js
+++ b/index.js
@@ -117,16 +117,21 @@ const plugin = fp(async function (app, opts) {
   let onConnect
 
   if (typeof subscriptionOpts === 'object') {
-    emitter = subscriptionOpts.emitter || mq()
+    if (subscriptionOpts.pubsub) {
+      subscriber = subscriptionOpts.pubsub
+    } else {
+      emitter = subscriptionOpts.emitter || mq()
+      subscriber = new PubSub(emitter)
+    }
     verifyClient = subscriptionOpts.verifyClient
     subscriptionContextFn = subscriptionOpts.context
     onConnect = subscriptionOpts.onConnect
   } else if (subscriptionOpts === true) {
     emitter = mq()
+    subscriber = new PubSub(emitter)
   }
 
   if (subscriptionOpts) {
-    subscriber = new PubSub(emitter)
     fastifyGraphQl.pubsub = subscriber
   }
 

--- a/lib/subscriber.js
+++ b/lib/subscriber.js
@@ -34,7 +34,7 @@ class PubSub {
   }
 }
 
-// One context - and  queue for each subscription
+// One context - and queue for each subscription
 class SubscriptionContext {
   constructor ({ pubsub, fastify }) {
     this.fastify = fastify


### PR DESCRIPTION
I would like to use other emitter clients, which do not follow `mqemitter` api. This should enable that use case.

Related #350 

For now I've typed the pubsub option as `any`, since using the `PubSub` there would lead to an incorrect interface.