### PR TITLE
fix: Build with tsc updating graphql to 15.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "fastify-plugin": "^2.0.1",
     "fastify-static": "^3.0.0",
     "fastify-websocket": "^2.0.5",
-    "graphql": "^15.0.0",
+    "graphql": "^15.4.0",
     "graphql-jit": "^0.4.0",
     "mqemitter": "^4.0.0",
     "p-map": "^4.0.0",


### PR DESCRIPTION
Fix #360 

Generic type for graphql `ExecutionResult` was introduced here: https://github.com/graphql/graphql-js/pull/2626