### PR TITLE
feat: add subscription.onDisconnect callback for subscriptions

### DIFF
--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -59,6 +59,7 @@
   - `subscription.verifyClient`: `Function` A function which can be used to validate incoming connections.
   - `subscription.context`: `Function` Result of function is passed to subscription resolvers as a custom GraphQL context. The function receives the `connection` and `request` as parameters.
   - `subscription.onConnect`: `Function` A function which can be used to validate the `connection_init` payload. If defined it should return a truthy value to authorize the connection. If it returns an object the subscription context will be extended with the returned object.
+    - `subscription.onDisconnect`: `Function` A function which is called with the subscription context of the connection after the connection gets disconnected.
 - `federationMetadata`: Boolean. Enable federation metadata support so the service can be deployed behind an Apollo Gateway
 - `gateway`: Object. Run the GraphQL server in gateway mode.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -263,6 +263,7 @@ export interface MercuriusCommonOptions {
           type: 'connection_init';
           payload: any;
         }) => Record<string, any> | Promise<Record<string, any>>;
+        onDisconnect?: (context: Record<string, any>) => void | Promise<void>;
       };
   /**
    * Enable federation metadata support so the service can be deployed behind an Apollo Gateway
@@ -313,10 +314,10 @@ export interface MercuriusCommonOptions {
   };
 
   /**
-   * It provides HTTP headers to GraphQL Playground. If it is an object, 
-   * it is provided as-is. If it is a function, it is serialized, injected 
-   * in the generated HTML and invoked with the `window` object as the argument. 
-   * Useful to read authorization token from browser's storage. 
+   * It provides HTTP headers to GraphQL Playground. If it is an object,
+   * it is provided as-is. If it is a function, it is serialized, injected
+   * in the generated HTML and invoked with the `window` object as the argument.
+   * Useful to read authorization token from browser's storage.
    * See [examples/playground.js](https://github.com/mercurius-js/mercurius/blob/master/examples/playground.js).
    */
   playgroundHeaders?: ((window: Window) => object) | object;

--- a/index.js
+++ b/index.js
@@ -115,6 +115,7 @@ const plugin = fp(async function (app, opts) {
   let verifyClient
   let subscriptionContextFn
   let onConnect
+  let onDisconnect
 
   if (typeof subscriptionOpts === 'object') {
     if (subscriptionOpts.pubsub) {
@@ -126,6 +127,7 @@ const plugin = fp(async function (app, opts) {
     verifyClient = subscriptionOpts.verifyClient
     subscriptionContextFn = subscriptionOpts.context
     onConnect = subscriptionOpts.onConnect
+    onDisconnect = subscriptionOpts.onDisconnect
   } else if (subscriptionOpts === true) {
     emitter = mq()
     subscriber = new PubSub(emitter)
@@ -226,6 +228,7 @@ const plugin = fp(async function (app, opts) {
       subscriber,
       verifyClient,
       onConnect,
+      onDisconnect,
       lruGatewayResolvers,
       entityResolversFactory,
       subscriptionContextFn

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -139,6 +139,7 @@ module.exports = async function (app, opts) {
     subscriber,
     verifyClient,
     onConnect,
+    onDisconnect,
     lruGatewayResolvers,
     entityResolversFactory,
     persistedQueryProvider,
@@ -253,6 +254,7 @@ module.exports = async function (app, opts) {
       subscriber,
       verifyClient,
       onConnect,
+      onDisconnect,
       lruGatewayResolvers,
       entityResolversFactory,
       subscriptionContextFn

--- a/lib/subscription-connection.js
+++ b/lib/subscription-connection.js
@@ -25,6 +25,7 @@ module.exports = class SubscriptionConnection {
     entityResolvers,
     context = {},
     onConnect,
+    onDisconnect,
     resolveContext
   }) {
     this.fastify = fastify
@@ -33,6 +34,7 @@ module.exports = class SubscriptionConnection {
     this.entityResolvers = entityResolvers
     this.subscriber = subscriber
     this.onConnect = onConnect
+    this.onDisconnect = onDisconnect
     this.subscriptionContexts = new Map()
     this.context = context
     this.isReady = false
@@ -208,6 +210,10 @@ module.exports = class SubscriptionConnection {
   }
 
   handleConnectionClose () {
+    if (typeof this.onDisconnect === 'function') {
+      this.onDisconnect(this.context)
+    }
+
     Array
       .from(this.subscriptionContexts.values())
       .map(subscriptionContext =>

--- a/lib/subscription-connection.js
+++ b/lib/subscription-connection.js
@@ -209,16 +209,20 @@ module.exports = class SubscriptionConnection {
     this.subscriptionContexts.delete(data.id)
   }
 
-  handleConnectionClose () {
-    if (typeof this.onDisconnect === 'function') {
-      this.onDisconnect(this.context)
-    }
-
+  async handleConnectionClose () {
     Array
       .from(this.subscriptionContexts.values())
       .map(subscriptionContext =>
         subscriptionContext.close())
     this.socket.close()
+
+    if (typeof this.onDisconnect === 'function') {
+      try {
+        await this.onDisconnect(this.context)
+      } catch (e) {
+        this.fastify.log.error(e)
+      }
+    }
   }
 
   sendMessage (type, id, payload) {

--- a/lib/subscription-connection.js
+++ b/lib/subscription-connection.js
@@ -209,7 +209,7 @@ module.exports = class SubscriptionConnection {
     this.subscriptionContexts.delete(data.id)
   }
 
-  async handleConnectionClose () {
+  handleConnectionClose () {
     Array
       .from(this.subscriptionContexts.values())
       .map(subscriptionContext =>
@@ -217,11 +217,9 @@ module.exports = class SubscriptionConnection {
     this.socket.close()
 
     if (typeof this.onDisconnect === 'function') {
-      try {
-        await this.onDisconnect(this.context)
-      } catch (e) {
-        this.fastify.log.error(e)
-      }
+      Promise.resolve()
+        .then(() => this.onDisconnect(this.context))
+        .catch((e) => { this.fastify.log.error(e) })
     }
   }
 

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -8,7 +8,7 @@ function handle (conn) {
   conn.end(JSON.stringify({ error: 'unknown route' }))
 }
 
-function createConnectionHandler ({ subscriber, fastify, onConnect, lruGatewayResolvers, entityResolversFactory, subscriptionContextFn }) {
+function createConnectionHandler ({ subscriber, fastify, onConnect, onDisconnect, lruGatewayResolvers, entityResolversFactory, subscriptionContextFn }) {
   return async (connection, request) => {
     const { socket } = connection
     if (socket.protocol === undefined ||
@@ -34,6 +34,7 @@ function createConnectionHandler ({ subscriber, fastify, onConnect, lruGatewayRe
       subscriber,
       fastify,
       onConnect,
+      onDisconnect,
       lruGatewayResolvers,
       entityResolvers: entityResolversFactory && entityResolversFactory.create(),
       context,
@@ -51,7 +52,7 @@ function createConnectionHandler ({ subscriber, fastify, onConnect, lruGatewayRe
 }
 
 module.exports = function (fastify, opts, next) {
-  const { getOptions, subscriber, verifyClient, onConnect, lruGatewayResolvers, entityResolversFactory, subscriptionContextFn } = opts
+  const { getOptions, subscriber, verifyClient, onConnect, onDisconnect, lruGatewayResolvers, entityResolversFactory, subscriptionContextFn } = opts
   fastify.register(fastifyWebsocket, {
     handle,
     options: {
@@ -66,6 +67,7 @@ module.exports = function (fastify, opts, next) {
       subscriber,
       fastify,
       onConnect,
+      onDisconnect,
       lruGatewayResolvers,
       entityResolversFactory,
       subscriptionContextFn

--- a/test/routes.js
+++ b/test/routes.js
@@ -1596,7 +1596,7 @@ test('connection is not allowed when onConnect callback throws', t => {
   })
 })
 
-test('onDisconnect called with connection context when connection gets disconnected', t => {
+test('onDisconnect is called with connection context when connection gets disconnected', t => {
   t.plan(1)
   const app = Fastify()
   t.tearDown(() => app.close())
@@ -1624,6 +1624,149 @@ test('onDisconnect called with connection context when connection gets disconnec
       },
       onDisconnect (context) {
         t.equal(context.test, 'custom')
+      }
+    }
+  })
+
+  app.listen(0, () => {
+    const url = 'ws://localhost:' + (app.server.address()).port + '/graphql'
+    const ws = new WebSocket(url, 'graphql-ws')
+    const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8', objectMode: true })
+    t.tearDown(client.destroy.bind(client))
+
+    client.setEncoding('utf8')
+    client.write(JSON.stringify({
+      type: 'connection_init'
+    }))
+    client.on('data', data => {
+      client.destroy()
+    })
+  })
+})
+
+test('promise returned from onDisconnect resolves', t => {
+  t.plan(1)
+
+  const app = Fastify()
+  t.tearDown(() => app.close())
+
+  const schema = `
+    type Query {
+      add(x: Int, y: Int): Int
+    }
+  `
+
+  const resolvers = {
+    Query: {
+      add: (parent, { x, y }) => x + y
+    }
+  }
+
+  app.register(GQL, {
+    schema,
+    resolvers,
+    subscription: {
+      onConnect (data) {
+        return {
+          test: 'custom'
+        }
+      },
+      async onDisconnect (context) {
+        t.equal(context.test, 'custom')
+      }
+    }
+  })
+
+  app.listen(0, () => {
+    const url = 'ws://localhost:' + (app.server.address()).port + '/graphql'
+    const ws = new WebSocket(url, 'graphql-ws')
+    const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8', objectMode: true })
+    t.tearDown(client.destroy.bind(client))
+
+    client.setEncoding('utf8')
+    client.write(JSON.stringify({
+      type: 'connection_init'
+    }))
+    client.on('data', data => {
+      client.destroy()
+    })
+  })
+})
+
+test('error thrown from onDisconnect is logged', t => {
+  t.plan(1)
+
+  const error = new Error('error')
+
+  const app = Fastify()
+  app.log.error = (e) => { t.deepEqual(error, e) }
+  t.tearDown(() => app.close())
+
+  const schema = `
+    type Query {
+      add(x: Int, y: Int): Int
+    }
+  `
+
+  const resolvers = {
+    Query: {
+      add: (parent, { x, y }) => x + y
+    }
+  }
+
+  app.register(GQL, {
+    schema,
+    resolvers,
+    subscription: {
+      onDisconnect () {
+        throw error
+      }
+    }
+  })
+
+  app.listen(0, () => {
+    const url = 'ws://localhost:' + (app.server.address()).port + '/graphql'
+    const ws = new WebSocket(url, 'graphql-ws')
+    const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8', objectMode: true })
+    t.tearDown(client.destroy.bind(client))
+
+    client.setEncoding('utf8')
+    client.write(JSON.stringify({
+      type: 'connection_init'
+    }))
+    client.on('data', data => {
+      client.destroy()
+    })
+  })
+})
+
+test('promise rejection from onDisconnect is logged', t => {
+  t.plan(1)
+
+  const error = new Error('error')
+
+  const app = Fastify()
+  app.log.error = (e) => { t.deepEqual(error, e) }
+  t.tearDown(() => app.close())
+
+  const schema = `
+    type Query {
+      add(x: Int, y: Int): Int
+    }
+  `
+
+  const resolvers = {
+    Query: {
+      add: (parent, { x, y }) => x + y
+    }
+  }
+
+  app.register(GQL, {
+    schema,
+    resolvers,
+    subscription: {
+      async onDisconnect () {
+        throw error
       }
     }
   })

--- a/test/routes.js
+++ b/test/routes.js
@@ -1596,6 +1596,54 @@ test('connection is not allowed when onConnect callback throws', t => {
   })
 })
 
+test('onDisconnect called with connection context when connection gets disconnected', t => {
+  t.plan(1)
+  const app = Fastify()
+  t.tearDown(() => app.close())
+
+  const schema = `
+    type Query {
+      add(x: Int, y: Int): Int
+    }
+  `
+
+  const resolvers = {
+    Query: {
+      add: (parent, { x, y }) => x + y
+    }
+  }
+
+  app.register(GQL, {
+    schema,
+    resolvers,
+    subscription: {
+      onConnect (data) {
+        return {
+          test: 'custom'
+        }
+      },
+      onDisconnect (context) {
+        t.equal(context.test, 'custom')
+      }
+    }
+  })
+
+  app.listen(0, () => {
+    const url = 'ws://localhost:' + (app.server.address()).port + '/graphql'
+    const ws = new WebSocket(url, 'graphql-ws')
+    const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8', objectMode: true })
+    t.tearDown(client.destroy.bind(client))
+
+    client.setEncoding('utf8')
+    client.write(JSON.stringify({
+      type: 'connection_init'
+    }))
+    client.on('data', data => {
+      client.destroy()
+    })
+  })
+})
+
 test('cached errors', async (t) => {
   const app = Fastify()
 

--- a/test/subscription-connection.js
+++ b/test/subscription-connection.js
@@ -61,7 +61,7 @@ test('socket is closed on unhandled promise rejection in handleMessage', t => {
   })
 })
 
-test('subscripction connection sends error message when message is not json string', async (t) => {
+test('subscription connection sends error message when message is not json string', async (t) => {
   t.plan(1)
 
   const sc = new SubscriptionConnection({


### PR DESCRIPTION
I was switching from Apollo Server to Mercurius, but I realized that the onDisconnect functionality that I used in Apollo Server which I used for cleanup in my app was missing from Mercurius. I saw a similar feature addition in #167 with the addition of onConnect, so I decided to add an onDisconnect alongside most places where I found onConnect, and so far it seems to be working.

In my use case, I need onDisconnect to be called with the context created by onConnect which contains the information I would need for cleanup, but I'm not sure if that's the best argument to pass to onDisconnect.

Thank you for your hard work on mercurius and I'm looking forward to using it! If there's any changes you'd like me to make with this PR, do let me know!