### PR TITLE
fix: Do not register fastify-websocket if it is already registered

### DIFF
--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -8,6 +8,7 @@
   - [Build a custom GraphQL context object for subscriptions](#build-a-custom-graphql-context-object-for-subscriptions)
   - [Subscription support (with redis)](#subscription-support-with-redis)
   - [Subscriptions with custom PubSub](#subscriptions-with-custom-pubsub)
+  - [Subscriptions with custom PubSub](#subscriptions-with-fastify-websocket)
 
 ### Subscription support (simple)
 
@@ -319,4 +320,35 @@ app.register(mercurius, {
   }
 })
 
+```
+
+### Subscriptions with fastify-websocket
+
+Mercurius uses `fastify-websocket` internally, but you can still use it by registering before `mercurius` plugin. If so, it is recommened to set appropriate `handle` and `options.maxPayload` like this:
+
+```js
+const fastifyWebsocket = require('fastify-websocket')
+
+function handle (conn) {
+  conn.end(JSON.stringify({ error: 'unknown route' }))
+}
+
+fastify.register(fastifyWebsocket, {
+  handle,
+  options: {
+    maxPayload: 1048576
+  }
+})
+
+app.register(mercurius, {
+  schema,
+  resolvers,
+  subscription: true
+})
+
+fastify.get('/', { websocket: true }, (connection, req) => {
+  connection.socket.on('message', message => {
+    connection.socket.send('hi from server')
+  })
+})
 ```

--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -333,7 +333,7 @@ function handle (conn) {
   conn.end(JSON.stringify({ error: 'unknown route' }))
 }
 
-fastify.register(fastifyWebsocket, {
+app.register(fastifyWebsocket, {
   handle,
   options: {
     maxPayload: 1048576
@@ -346,7 +346,7 @@ app.register(mercurius, {
   subscription: true
 })
 
-fastify.get('/', { websocket: true }, (connection, req) => {
+app.get('/', { websocket: true }, (connection, req) => {
   connection.socket.on('message', message => {
     connection.socket.send('hi from server')
   })

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -52,13 +52,18 @@ function createConnectionHandler ({ subscriber, fastify, onConnect, lruGatewayRe
 
 module.exports = function (fastify, opts, next) {
   const { getOptions, subscriber, verifyClient, onConnect, lruGatewayResolvers, entityResolversFactory, subscriptionContextFn } = opts
-  fastify.register(fastifyWebsocket, {
-    handle,
-    options: {
-      maxPayload: 1048576,
-      verifyClient
-    }
-  })
+
+  // If `fastify.websocketServer` exists, it means `fastify-websocket` already registered.
+  // Without this check, fastify-websocket will be registered multiple times and raises FST_ERR_DEC_ALREADY_PRESENT.
+  if (fastify.websocketServer === undefined) {
+    fastify.register(fastifyWebsocket, {
+      handle,
+      options: {
+        maxPayload: 1048576,
+        verifyClient
+      }
+    })
+  }
 
   fastify.route({
     ...getOptions,

--- a/test/subscription.js
+++ b/test/subscription.js
@@ -3,6 +3,7 @@ const Fastify = require('fastify')
 const WebSocket = require('ws')
 const mq = require('mqemitter')
 const { EventEmitter } = require('events')
+const fastifyWebsocket = require('fastify-websocket')
 const GQL = require('..')
 
 const FakeTimers = require('@sinonjs/fake-timers')
@@ -1749,5 +1750,35 @@ test('`withFilter` tool works with async filters', t => {
         }, () => { t.pass() })
       }
     })
+  })
+})
+
+test('subscription server does not register fastify-websocket if already registered', t => {
+  const app = Fastify()
+  t.tearDown(() => app.close())
+
+  const schema = `
+    type Query {
+      add(x: Int, y: Int): Int
+    }
+  `
+
+  const resolvers = {
+    Query: {
+      add: (parent, { x, y }) => x + y
+    }
+  }
+
+  app.register(fastifyWebsocket)
+
+  app.register(GQL, {
+    schema,
+    resolvers,
+    subscription: true
+  })
+
+  app.listen(0, err => {
+    t.error(err)
+    t.end()
   })
 })

--- a/test/subscription.js
+++ b/test/subscription.js
@@ -1753,12 +1753,21 @@ test('`withFilter` tool works with async filters', t => {
   })
 })
 
-test('subscription server does not register fastify-websocket if already registered', t => {
+test('subscription server works with fastify-websocket', t => {
   const app = Fastify()
   t.tearDown(() => app.close())
   t.plan(3)
 
-  app.register(fastifyWebsocket)
+  function handle (conn) {
+    conn.end(JSON.stringify({ error: 'unknown route' }))
+  }
+
+  app.register(fastifyWebsocket, {
+    handle,
+    options: {
+      maxPayload: 1048576
+    }
+  })
 
   app.get('/fastify-websocket', { websocket: true }, (connection, req) => {
     connection.socket.on('message', message => {


### PR DESCRIPTION
Hi, thank you for the great library.

This PR fixes https://github.com/mercurius-js/mercurius/issues/369, which enables `mercurius` to work with `fastify-websocket`.

As @mcollina suggested on https://github.com/mercurius-js/mercurius/issues/369#issuecomment-751381695, I've added a check if `fastify-websocket` is already registered or not.

- My determination is that checking the decorator `fastify.websocketServer` is `undefined` or not. I think there should be a method to check a plugin registered or not, but this is what I know about Fastify.
- I've added a simple test for coverage. I've confirmed subscription is working even if `fastify-websocket` is already registered on my machine, but I'll happy to add more tests if needed.
 
Thanks!