### PR TITLE
Upgrade to fastify-websocket 3.0.0 for plugin encapsulation support

### DIFF
--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -324,17 +324,12 @@ app.register(mercurius, {
 
 ### Subscriptions with fastify-websocket
 
-Mercurius uses `fastify-websocket` internally, but you can still use it by registering before `mercurius` plugin. If so, it is recommened to set appropriate `handle` and `options.maxPayload` like this:
+Mercurius uses `fastify-websocket` internally, but you can still use it by registering before `mercurius` plugin. If so, it is recommened to set the appropriate `options.maxPayload` like this:
 
 ```js
 const fastifyWebsocket = require('fastify-websocket')
 
-function handle (conn) {
-  conn.end(JSON.stringify({ error: 'unknown route' }))
-}
-
 app.register(fastifyWebsocket, {
-  handle,
   options: {
     maxPayload: 1048576
   }

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -6,10 +6,6 @@ const { kHooks } = require('./symbols')
 const SubscriptionConnection = require('./subscription-connection')
 const GRAPHQL_WS = 'graphql-ws'
 
-function handle (conn) {
-  conn.end(JSON.stringify({ error: 'unknown route' }))
-}
-
 function createConnectionHandler ({ subscriber, fastify, onConnect, onDisconnect, lruGatewayResolvers, entityResolversFactory, subscriptionContextFn }) {
   return async (connection, request) => {
     const { socket } = connection
@@ -67,7 +63,6 @@ module.exports = function (fastify, opts, next) {
   // Without this check, fastify-websocket will be registered multiple times and raises FST_ERR_DEC_ALREADY_PRESENT.
   if (fastify.websocketServer === undefined) {
     fastify.register(fastifyWebsocket, {
-      handle,
       options: {
         maxPayload: 1048576,
         verifyClient

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "fastify-error": "^0.2.0",
     "fastify-plugin": "^2.0.1",
     "fastify-static": "^3.4.0",
-    "fastify-websocket": "^2.0.11",
+    "fastify-websocket": "^3.0.0",
     "graphql": "^15.4.0",
     "graphql-jit": "^0.5.0",
     "mqemitter": "^4.0.0",

--- a/test/subscription.js
+++ b/test/subscription.js
@@ -598,43 +598,6 @@ test('subscription server sends update to subscriptions with custom context', t 
   })
 })
 
-test('subscription server register handle function arg is not empty', t => {
-  const app = Fastify()
-  const schema = `
-    type Query {
-      add(x: Int, y: Int): Int
-    }
-  `
-
-  const resolvers = {
-    add: async ({ x, y }) => x + y
-  }
-
-  t.tearDown(app.close)
-
-  app.register(GQL, {
-    schema,
-    resolvers,
-    subscription: true
-  })
-
-  app.listen(0, err => {
-    t.error(err)
-
-    const url = 'ws://localhost:' + (app.server.address()).port + '/'
-    const ws = new WebSocket(url)
-    const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8', objectMode: true })
-    t.tearDown(client.destroy.bind(client))
-
-    client.setEncoding('utf8')
-    client.on('data', chunk => {
-      t.equal(chunk, '{"error":"unknown route"}')
-      client.end()
-      t.end()
-    })
-  })
-})
-
 test('subscription socket protocol different than graphql-ws, protocol = foobar', t => {
   const app = Fastify()
   const schema = `
@@ -1758,12 +1721,7 @@ test('subscription server works with fastify-websocket', t => {
   t.tearDown(() => app.close())
   t.plan(3)
 
-  function handle (conn) {
-    conn.end(JSON.stringify({ error: 'unknown route' }))
-  }
-
   app.register(fastifyWebsocket, {
-    handle,
     options: {
       maxPayload: 1048576
     }


### PR DESCRIPTION
This uses the new version of `fastify-websocket` that has support for running hooks before upgrading to websockets inside mercurius, which means things like auth hooks will apply to both http and websocket routes registered by mercurius! Woop! See https://github.com/fastify/fastify-websocket/pull/95 for more details. This also means that custom `verifyClient` functions should be needed less frequently, as you can just rely on `preValidation` hooks wrapping mercurius to apply to all of it.

Only real change I had to made was removing the globally installed websocket handler that replied with an unknown route, which I don't think makes much sense to install anymore now that `fastify-websocket` uses the normal Fastify router and hooks system. 

I think this is semver major though because now hooks will apply to subscription routes registered by mercurius, whereas they wouldn't have before, and also this global not found route handler has been removed. 