### PR TITLE
fix: custom entity cache id

### DIFF
--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -314,7 +314,7 @@ async function buildGateway (gatewayOpts, app) {
       }))
 
       return result
-    })
+    }, query => query.id)
   }
 
   typeToServiceMap.Query = null

--- a/lib/gateway/make-resolver.js
+++ b/lib/gateway/make-resolver.js
@@ -359,7 +359,8 @@ function makeResolver ({ service, createOperation, transformData, isQuery, isRef
 
     if (isReference && !parent[fieldName]) return null
 
-    const resolverKey = generatePathKey(info.path).join('.').replace(/\d/g, '_IDX_')
+    const queryId = generatePathKey(info.path).join('.')
+    const resolverKey = queryId.replace(/\d/g, '_IDX_')
     const { reply, __currentQuery, lruGatewayResolvers, pubsub } = context
 
     const cached = lruGatewayResolvers.get(`${__currentQuery}_${resolverKey}`)
@@ -466,7 +467,8 @@ function makeResolver ({ service, createOperation, transformData, isQuery, isRef
       query,
       variables,
       originalRequestHeaders: reply.request.headers,
-      context
+      context,
+      id: queryId
     })
 
     return transformData(response)

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "promise.allsettled": "^1.0.2",
     "readable-stream": "^3.5.0",
     "secure-json-parse": "^2.2.0",
-    "single-user-cache": "^0.3.0",
+    "single-user-cache": "^0.4.0",
     "tiny-lru": "^7.0.2",
     "undici": "^3.0.0",
     "ws": "^7.4.2"


### PR DESCRIPTION
may resolve #397, or at least the CPU usage issue

This PR changes the id used for the entity resolver caching. It uses the query path instead of the full query object which could be quite heavy to serialize. 