### PR TITLE
fix(types): missing reply in context

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,6 +26,7 @@ export interface PubSub {
 
 export interface MercuriusContext {
   app: FastifyInstance;
+  reply: FastifyReply;
   /**
    * __Caution__: Only available if `subscriptions` are enabled
    */

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -52,7 +52,6 @@ const resolvers: IResolvers = {
 declare module '../../' {
   interface MercuriusContext {
     request: FastifyRequest
-    reply: FastifyReply
   }
 }
 
@@ -74,10 +73,9 @@ app.register(mercurius, {
   },
   queryDepth: 8,
   cache: true,
-  context: (request, reply) => {
+  context: (request) => {
     return {
-      request,
-      reply
+      request
     }
   },
   schemaTransforms: (schema) => schema


### PR DESCRIPTION
Adds missing reply type to context. No need to pass it in `context` function, since it's passed already,

Closes #404