### PR TITLE
fix(types): mark 'schema' optional in 'MercuriusSchemaOptions'

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -271,7 +271,7 @@ export interface MercuriusSchemaOptions {
   /**
    * The GraphQL schema. String schema will be parsed
    */
-  schema: GraphQLSchema | string | string[];
+  schema?: GraphQLSchema | string | string[];
   /**
    * Object with resolver functions
    */

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -131,6 +131,10 @@ app.register(mercurius, {
   subscription: true
 })
 
+// all params are optional
+const opts: MercuriusOptions = {}
+app.register(mercurius, opts)
+
 app.register(async function (app) {
   app.graphql.extendSchema(`
     type Human {


### PR DESCRIPTION
At the moment arg 'schema' is not optional in type 'MercuriusSchemaOptions'. Because of this one gets and error if plugin is registered with 'schema' in options. An example of code which will throw Typescript error:

```
app.register(mercurius, { path: '/' })

app.register(async function (app) {
  app.graphql.extendSchema(schema)
})
```

You can also see the Typescript error in included test.

The code works as expected. Seems like typings are incorrect.