### PR TITLE
fix: improve error messaging for gateway

### DIFF
--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -171,9 +171,16 @@ async function buildGateway (gatewayOpts, app) {
   const { services, errorHandler = defaultErrorHandler } = gatewayOpts
 
   const serviceMap = await buildServiceMap(services, errorHandler)
-  const serviceSDLs = Object.values(serviceMap)
-    .map(service => service.schemaDefinition)
-    .filter(schemaDefinition => schemaDefinition !== '')
+
+  const serviceSDLs = Object.entries(serviceMap).reduce((acc, [name, value]) => {
+    const { schemaDefinition, error } = value
+
+    error !== null
+      ? app.log.warn(`Initializing service "${name}" failed with message: "${error.message}"`)
+      : acc.push(schemaDefinition)
+
+    return acc
+  }, [])
 
   if (serviceSDLs.length < 1) {
     throw new MER_ERR_GQL_GATEWAY_INIT('No valid service SDLs were provided')

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -17,7 +17,7 @@ const {
   createEntityReferenceResolverOperation,
   kEntityResolvers
 } = require('./gateway/make-resolver')
-const { MER_ERR_GQL_GATEWAY_REFRESH } = require('./errors')
+const { MER_ERR_GQL_GATEWAY_REFRESH, MER_ERR_GQL_GATEWAY_INIT } = require('./errors')
 const { preGatewayExecutionHandler } = require('./handlers')
 
 const allSettled = require('promise.allsettled')
@@ -171,8 +171,13 @@ async function buildGateway (gatewayOpts, app) {
   const { services, errorHandler = defaultErrorHandler } = gatewayOpts
 
   const serviceMap = await buildServiceMap(services, errorHandler)
+  const serviceSDLs = Object.values(serviceMap)
+    .map(service => service.schemaDefinition)
+    .filter(schemaDefinition => schemaDefinition !== '')
 
-  const serviceSDLs = Object.values(serviceMap).map(service => service.schemaDefinition)
+  if (serviceSDLs.length < 1) {
+    throw new MER_ERR_GQL_GATEWAY_INIT('No valid service SDLs were provided')
+  }
 
   const schema = buildFederatedSchema(serviceSDLs.join(''), true)
 

--- a/lib/gateway/service-map.js
+++ b/lib/gateway/service-map.js
@@ -197,10 +197,15 @@ async function buildServiceMap (services, errorHandler) {
   }
 
   const mapper = async service => {
-    const serviceConfig = await serviceMap[service.name].init()
-      .catch((err) => {
-        errorHandler(err, service)
-      })
+    let serviceConfig
+    let serviceConfigErr
+
+    try {
+      serviceConfig = await serviceMap[service.name].init()
+    } catch (err) {
+      serviceConfigErr = err
+      errorHandler(err, service)
+    }
 
     if (serviceConfig) {
       serviceMap[service.name].schema = serviceConfig.schema
@@ -208,12 +213,14 @@ async function buildServiceMap (services, errorHandler) {
       serviceMap[service.name].typeMap = serviceConfig.typeMap
       serviceMap[service.name].types = serviceConfig.types
       serviceMap[service.name].extensionTypeMap = serviceConfig.extensionTypeMap
+      serviceMap[service.name].error = null
     } else {
       serviceMap[service.name].schema = new GraphQLSchema({})
       serviceMap[service.name].schemaDefinition = ''
       serviceMap[service.name].typeMap = {}
       serviceMap[service.name].types = new Set()
       serviceMap[service.name].extensionTypeMap = {}
+      serviceMap[service.name].error = serviceConfigErr
     }
 
     serviceMap[service.name].name = service.name

--- a/tap-snapshots/test-gateway-remote-services.js-TAP.test.js
+++ b/tap-snapshots/test-gateway-remote-services.js-TAP.test.js
@@ -1,0 +1,10 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports['test/gateway/remote-services.js TAP Does not error if at least one service schema is valid > must match snapshot 1'] = `
+Initializing service "not-working" failed with message: "Unknown type "World"."
+`

--- a/test/gateway/remote-services.js
+++ b/test/gateway/remote-services.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('tap')
 const Fastify = require('fastify')
 const GQL = require('../..')
@@ -38,7 +40,7 @@ test('Throws an Error if there are no valid services', async (t) => {
   gateway.register(GQL, {
     gateway: {
       services: [{
-        name: 'working',
+        name: 'not-working',
         url: `http://localhost:${servicePort}/graphql`
       }]
     }

--- a/test/gateway/remote-services.js
+++ b/test/gateway/remote-services.js
@@ -1,0 +1,113 @@
+const { test } = require('tap')
+const Fastify = require('fastify')
+const GQL = require('../..')
+
+const invalidSchema = `
+  extend type Query {
+    hello: World!
+  }
+`
+
+const validSchema = `
+  extend type Query {
+    foo: String!
+  }
+`
+
+async function createRemoteService (schema) {
+  const service = Fastify()
+  service.post('/graphql', async (request, reply) => {
+    reply.send({ data: { _service: { sdl: schema } } })
+  })
+
+  await service.listen(0)
+
+  return [service, service.server.address().port]
+}
+
+test('Throws an Error if there are no valid services', async (t) => {
+  const [service, servicePort] = await createRemoteService(invalidSchema)
+
+  const gateway = Fastify()
+
+  t.tearDown(async () => {
+    await gateway.close()
+    await service.close()
+  })
+
+  gateway.register(GQL, {
+    gateway: {
+      services: [{
+        name: 'working',
+        url: `http://localhost:${servicePort}/graphql`
+      }]
+    }
+  })
+
+  try {
+    await gateway.ready()
+  } catch (err) {
+    t.is(err.message, 'Gateway schema init issues No valid service SDLs were provided')
+  }
+})
+
+test('Returns schema related errors for mandatory services', async (t) => {
+  const [service, servicePort] = await createRemoteService(invalidSchema)
+
+  const gateway = Fastify()
+
+  t.tearDown(async () => {
+    await gateway.close()
+    await service.close()
+  })
+
+  gateway.register(GQL, {
+    gateway: {
+      services: [{
+        name: 'not-working',
+        url: `http://localhost:${servicePort}/graphql`,
+        mandatory: true
+      }]
+    }
+  })
+
+  try {
+    await gateway.ready()
+  } catch (err) {
+    t.is(err.message, 'Unknown type "World".')
+  }
+})
+
+test('Does not error if at least one service schema is valid', async (t) => {
+  const [service, servicePort] = await createRemoteService(validSchema)
+  const [invalidService, invalidServicePort] = await createRemoteService(invalidSchema)
+
+  const gateway = Fastify()
+
+  t.tearDown(async () => {
+    await gateway.close()
+    await service.close()
+    await invalidService.close()
+  })
+
+  gateway.register(GQL, {
+    gateway: {
+      services: [
+        {
+          name: 'working',
+          url: `http://localhost:${servicePort}/graphql`
+        },
+        {
+          name: 'not-working',
+          url: `http://localhost:${invalidServicePort}/graphql`
+        }
+      ]
+    }
+  })
+
+  try {
+    await gateway.ready()
+  } catch (err) {
+    t.error(err)
+  }
+})

--- a/test/gateway/remote-services.js
+++ b/test/gateway/remote-services.js
@@ -84,7 +84,15 @@ test('Does not error if at least one service schema is valid', async (t) => {
   const [service, servicePort] = await createRemoteService(validSchema)
   const [invalidService, invalidServicePort] = await createRemoteService(invalidSchema)
 
-  const gateway = Fastify()
+  const gateway = Fastify({
+    logger: true
+  })
+
+  let warnCalled = 0
+  gateway.log.warn = (message) => {
+    warnCalled++
+    t.matchSnapshot(message)
+  }
 
   t.tearDown(async () => {
     await gateway.close()
@@ -112,4 +120,5 @@ test('Does not error if at least one service schema is valid', async (t) => {
   } catch (err) {
     t.error(err)
   }
+  t.equal(warnCalled, 1, 'Warning is called')
 })


### PR DESCRIPTION
# Summary

Adds some additional error messaging for gateways that are configured to consume remote services. Previously, if a gateway loaded a remote service and that service had an invalid schema, the gateway would attempt to build a federated schema  and the result of that is a GQL parsing error: `Syntax Error: Unexpected <EOF>.`. 

This pull request adds an additional check before attempting to build the federated schema. If there are no valid SDLs that have been provided to the gateway, we inform the user that this is the case. 

I also added a couple of tests that check the error handling behaviour of a gateway that is consuming remote services.

# Caveats

This is probably more useful for development, but I though this messaging might help other developers locate similar issues faster than it took me!
