### PR TITLE
feat(gateway): extend undici agent options

### DIFF
--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -69,6 +69,10 @@
     - `service.rewriteHeaders`: `Function` A function that gets the original headers as a parameter and returns an object containing values that should be added to the headers
     - `service.initHeaders`: `Function` or `Object` An object or a function that returns the headers sent to the service for the initial \_service SDL query.
     - `service.connections`: The number of clients to create. (Default: `10`)
+    - `service.bodyTimeout`: The timeout after which a request will time out, in milliseconds. (Default: `30e3` - 30 seconds)
+    - `service.headersTimeout`: The amount of time the parser will wait to receive the complete HTTP headers, in milliseconds. (Default: `30e3` - 30 seconds)
+    - `service.keepAliveMaxTimeout`: The maximum allowed keepAliveTimeout. (Default: `5e3` - 5 seconds)
+    - `service.maxHeaderSize`: The maximum length of request headers in bytes. (Default: `16384` - 16KiB)
     - `service.wsUrl`: The url of the websocket endpoint
     - `service.wsConnectionParams`: `Function` or `Object`
       - `wsConnectionParams.connectionInitPayload`: `Function` or `Object` An object or a function that returns the `connection_init` payload sent to the service.

--- a/lib/gateway/request.js
+++ b/lib/gateway/request.js
@@ -7,6 +7,9 @@ const sJSON = require('secure-json-parse')
 
 function agentOption (opts) {
   return {
+    bodyTimeout: opts.bodyTimeout || 30e3, // 30 seconds
+    headersTimeout: opts.headersTimeout || 30e3, // 30 seconds
+    maxHeaderSize: opts.maxHeaderSize || 16384, // 16 KiB
     keepAliveMaxTimeout: opts.keepAliveMaxTimeout || opts.keepAliveMsecs || 5 * 1000, // 5 seconds
     connections: opts.connections || opts.maxSockets || 10,
     tls: {


### PR DESCRIPTION
This PR extends the options available for the gateway services clients (undici) and the documentation.