### PR TITLE
Access context in rewriteHeaders

### DIFF
--- a/docs/federation.md
+++ b/docs/federation.md
@@ -168,7 +168,7 @@ gateway.register(mercurius, {
       {
         name: 'user',
         url: 'http://localhost:4001/graphql',
-        rewriteHeaders: (headers, context = undefined) => {
+        rewriteHeaders: (headers, context) => {
           if (headers.authorization) {
             return {
               authorization: headers.authorization

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -168,7 +168,7 @@ gateway.register(mercurius, {
       {
         name: 'user',
         url: 'http://localhost:4001/graphql',
-        rewriteHeaders: (headers, context) => {
+        rewriteHeaders: (headers, context = undefined) => {
           if (headers.authorization) {
             return {
               authorization: headers.authorization

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -168,7 +168,7 @@ gateway.register(mercurius, {
       {
         name: 'user',
         url: 'http://localhost:4001/graphql',
-        rewriteHeaders: (headers) => {
+        rewriteHeaders: (headers, context) => {
           if (headers.authorization) {
             return {
               authorization: headers.authorization

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -308,7 +308,8 @@ async function buildGateway (gatewayOpts, app) {
           body: JSON.stringify({
             query: modifiedQuery || query,
             variables
-          })
+          }),
+          context: queries[queryIndex].context
         })
 
         let entityIndex = 0

--- a/lib/gateway/make-resolver.js
+++ b/lib/gateway/make-resolver.js
@@ -467,7 +467,8 @@ function makeResolver ({ service, createOperation, transformData, isQuery, isRef
           query: modifiedQuery || query,
           variables
         }),
-        originalRequestHeaders: reply.request.headers
+        originalRequestHeaders: reply.request.headers,
+        context
       })
 
       return transformData(response)

--- a/lib/gateway/request.js
+++ b/lib/gateway/request.js
@@ -33,7 +33,7 @@ function buildRequest (opts) {
       method: opts.method,
       path: opts.url.pathname + (opts.qs || ''),
       headers: {
-        ...rewriteHeaders(opts.originalRequestHeaders),
+        ...rewriteHeaders(opts.originalRequestHeaders, opts.context),
         ...opts.headers
       },
       body: opts.body
@@ -61,7 +61,8 @@ function sendRequest (request, url) {
           'content-type': 'application/json',
           'content-length': Buffer.byteLength(opts.body)
         },
-        originalRequestHeaders: opts.originalRequestHeaders || {}
+        originalRequestHeaders: opts.originalRequestHeaders || {},
+        context: opts.context
       }, (err, response) => {
         if (err) {
           return reject(err)

--- a/lib/gateway/service-map.js
+++ b/lib/gateway/service-map.js
@@ -85,8 +85,7 @@ async function getRemoteSchemaDefinition (serviceConfig, initHeaders) {
         }
         `
     }),
-    headers,
-    context: {} // No context to pass at this stage
+    headers
   })
 
   const {

--- a/lib/gateway/service-map.js
+++ b/lib/gateway/service-map.js
@@ -85,7 +85,8 @@ async function getRemoteSchemaDefinition (serviceConfig, initHeaders) {
         }
         `
     }),
-    headers
+    headers,
+    context: {} // No context to pass at this stage
   })
 
   const {

--- a/test/gateway/rewrite-headers.js
+++ b/test/gateway/rewrite-headers.js
@@ -42,7 +42,7 @@ async function createUserService ({ hooks } = {}) {
   return await createTestService(schema, resolvers, hooks)
 }
 
-test('gateway - rewriteHeaders', async (t) => {
+test('gateway - service rewriteHeaders', async (t) => {
   t.test('rewriteHeaders is called as expected', async (t) => {
     t.plan(5)
 

--- a/test/gateway/rewrite-headers.js
+++ b/test/gateway/rewrite-headers.js
@@ -1,0 +1,101 @@
+'use strict'
+
+const { test } = require('tap')
+const Fastify = require('fastify')
+const GQL = require('../..')
+
+async function createTestService (t, schema, resolvers = {}) {
+  const service = Fastify()
+  service.register(GQL, {
+    schema,
+    resolvers,
+    federationMetadata: true
+  })
+  await service.listen(0)
+  return [service, service.server.address().port]
+}
+
+const users = {
+  u1: {
+    id: 'u1',
+    name: 'John'
+  },
+  u2: {
+    id: 'u2',
+    name: 'Jane'
+  }
+}
+
+async function createTestGatewayServer (t) {
+  // User service
+  const userServiceSchema = `
+  type Query @extends {
+    me: User
+  }
+
+  type User @key(fields: "id") {
+    id: ID!
+    name: String!
+  }`
+
+  const userServiceResolvers = {
+    Query: {
+      me: (root, args, context, info) => {
+        return users.u1
+      }
+    }
+  }
+  const [userService, userServicePort] = await createTestService(t, userServiceSchema, userServiceResolvers)
+
+  const gateway = Fastify()
+
+  t.teardown(async () => {
+    await gateway.close()
+    await userService.close()
+  })
+
+  gateway.register(GQL, {
+    gateway: {
+      services: [
+        {
+          name: 'user',
+          url: `http://localhost:${userServicePort}/graphql`,
+          rewriteHeaders: (headers, context) => {
+            t.ok(headers != null, 'Expected `headers` to have been passed in')
+            t.ok(context != null, 'Expected `context` to have been passed in')
+          }
+        }
+      ]
+    }
+  })
+
+  return gateway
+}
+
+test('gateway - rewriteHeaders', async (t) => {
+  const app = await createTestGatewayServer(t)
+
+  const query = `
+    query {
+      user: me {
+        id
+        name
+      }
+    }`
+
+  const res = await app.inject({
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    url: '/graphql',
+    body: JSON.stringify({ query })
+  })
+
+  t.same(JSON.parse(res.body), {
+    data: {
+      user: {
+        id: 'u1',
+        name: 'John'
+      }
+    }
+  })
+})

--- a/test/gateway/rewrite-headers.js
+++ b/test/gateway/rewrite-headers.js
@@ -4,31 +4,26 @@ const { test } = require('tap')
 const Fastify = require('fastify')
 const GQL = require('../..')
 
-async function createTestService (t, schema, resolvers = {}) {
+async function createTestService (schema, resolvers = {}, hooks = {}) {
   const service = Fastify()
-  service.register(GQL, {
-    schema,
-    resolvers,
-    federationMetadata: true
+  service.register(GQL, { schema, resolvers, federationMetadata: true })
+
+  Object.entries(hooks).forEach(([hookName, handler]) => {
+    service.addHook(hookName, handler)
   })
+
   await service.listen(0)
   return [service, service.server.address().port]
 }
 
-const users = {
-  u1: {
-    id: 'u1',
-    name: 'John'
-  },
-  u2: {
-    id: 'u2',
-    name: 'Jane'
-  }
+const TEST_USERS = {
+  u1: { id: 'u1', name: 'John' },
+  u2: { id: 'u2', name: 'Jane' }
 }
 
-async function createTestGatewayServer (t) {
-  // User service
-  const userServiceSchema = `
+// User service
+async function createUserService ({ hooks } = {}) {
+  const schema = `
   type Query @extends {
     me: User
   }
@@ -38,64 +33,76 @@ async function createTestGatewayServer (t) {
     name: String!
   }`
 
-  const userServiceResolvers = {
+  const resolvers = {
     Query: {
-      me: (root, args, context, info) => {
-        return users.u1
-      }
+      me: () => TEST_USERS.u1
     }
   }
-  const [userService, userServicePort] = await createTestService(t, userServiceSchema, userServiceResolvers)
 
-  const gateway = Fastify()
-
-  t.teardown(async () => {
-    await gateway.close()
-    await userService.close()
-  })
-
-  gateway.register(GQL, {
-    gateway: {
-      services: [
-        {
-          name: 'user',
-          url: `http://localhost:${userServicePort}/graphql`,
-          rewriteHeaders: (headers, context) => {
-            t.ok(headers != null, 'Expected `headers` to have been passed in')
-            t.ok(context != null, 'Expected `context` to have been passed in')
-          }
-        }
-      ]
-    }
-  })
-
-  return gateway
+  return await createTestService(schema, resolvers, hooks)
 }
 
 test('gateway - rewriteHeaders', async (t) => {
-  const app = await createTestGatewayServer(t)
+  t.test('rewriteHeaders is called as expected', async (t) => {
+    t.plan(5)
 
-  const query = `
-    query {
-      user: me {
-        id
-        name
-      }
-    }`
+    const gateway = Fastify()
 
-  const res = await app.inject({
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    url: '/graphql',
-    body: JSON.stringify({ query })
+    const rewriteHeaders = (headers, context = 'not-passed') => {
+      t.ok(headers != null, 'Headers is never undefined/null')
+
+      // `context` isn't available from `getRemoteSchemaDefinition`
+      // as such assert it's 'not-passed' OR includes `app` exact instance
+      t.ok(context === 'not-passed' || context.app === gateway)
+    }
+
+    const [users, usersPort] = await createUserService()
+    const url = `http://localhost:${usersPort}/graphql`
+    gateway.register(GQL, { gateway: { services: [{ name: 'user', url, rewriteHeaders }] } })
+
+    t.teardown(async () => {
+      await users.close()
+      await gateway.close()
+    })
+
+    const res = await gateway.inject({
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      url: '/graphql',
+      body: JSON.stringify({ query: 'query { user: me { id name } }' })
+    })
+
+    const expected = { data: { user: { id: 'u1', name: 'John' } } }
+    t.same(expected, JSON.parse(res.body))
   })
 
-  t.same(JSON.parse(res.body), {
-    data: {
-      user: {
-        id: 'u1',
-        name: 'John'
-      }
+  t.test('returned headers are sent to graphql service', async (t) => {
+    t.plan(3)
+
+    const custom = `Testing-${Math.trunc(Math.random() * 100)}`
+    const onRequest = async (req) => {
+      t.ok(req.headers['x-custom'] === custom)
     }
+
+    const [users, usersPort] = await createUserService({ hooks: { onRequest } })
+    const url = `http://localhost:${usersPort}/graphql`
+    const gateway = Fastify()
+    const rewriteHeaders = () => ({ 'x-custom': custom })
+    gateway.register(GQL, { gateway: { services: [{ name: 'user', url, rewriteHeaders }] } })
+
+    t.teardown(async () => {
+      await users.close()
+      await gateway.close()
+    })
+
+    const res = await gateway.inject({
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      url: '/graphql',
+      body: JSON.stringify({ query: 'query { user: me { id name } }' })
+    })
+
+    const expected = { data: { user: { id: 'u1', name: 'John' } } }
+    t.same(expected, JSON.parse(res.body))
   })
 })


### PR DESCRIPTION
Fix #431 

On gateway setups, query `context` was not being exposed to `rewriteHeaders`.
This PR fixes the issue by passing the `context` to every call to `serviceDefinition.sendRequest` which then exposes it to `rewriteHeaders` as an additional parameter.