### PR TITLE
Add support for Mercurius auth plugin

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -233,7 +233,7 @@ fastify.graphql.addHook('preSubscriptionParsing', async (schema, source, context
 
 ## GraphQL Application lifecycle Hooks
 
-There is one hook that you can use in a GraphQL application:
+There is one hook that you can use in a GraphQL application.
 
 When registering hooks, you must wait for Mercurius to be registered in Fastify.
 
@@ -243,7 +243,7 @@ await fastify.ready()
 
 ### onGatewayReplaceSchema
 
-The `onGatewayReplaceSchema` hook will be triggered every time the periodic gateway refresh builds a new schema. It is called just before the old schema is replaced with the new one.
+When the Gateway service obtains new versions of federated schemas within a defined polling interval, the `onGatewayReplaceSchema` hook will be triggered every time a new schema is built. It is called just before the old schema is replaced with the new one.
 
 This hook will only be triggered in gateway mode. It has the following parameters:
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -230,3 +230,30 @@ fastify.graphql.addHook('preSubscriptionParsing', async (schema, source, context
   throw new Error('Some error')
 })
 ```
+
+## GraphQL Application lifecycle Hooks
+
+There is one hook that you can use in a GraphQL application:
+
+When registering hooks, you must wait for Mercurius to be registered in Fastify.
+
+```js
+await fastify.ready()
+```
+
+### onGatewayReplaceSchema
+
+The `onGatewayReplaceSchema` hook will be triggered every time the periodic gateway refresh builds a new schema. It is called just before the old schema is replaced with the new one.
+
+This hook will only be triggered in gateway mode. It has the following parameters:
+
+ - `instance` - The gateway server `FastifyInstance` (this contains the old schema).
+ - `schema` - The new schema that has been built from the gateway refresh.
+
+```js
+fastify.graphql.addHook('onGatewayReplaceSchema', async (instance, schema) => {
+  await someSchemaTraversalFn()
+})
+```
+
+If this hook throws, the error will be caught and logged using the `FastifyInstance` logger. Subsequent `onGatewayReplaceSchema` hooks that are registered will not be run for this interval.

--- a/examples/hooks-gateway.js
+++ b/examples/hooks-gateway.js
@@ -216,6 +216,10 @@ async function start () {
     console.log('onResolution called')
   })
 
+  gateway.graphql.addHook('onGatewayReplaceSchema', async (instance, schema) => {
+    console.log('onGatewayReplaceSchema called')
+  })
+
   await gateway.listen(4000)
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -203,6 +203,23 @@ export interface onSubscriptionEndHookHandler<TContext = MercuriusContext> {
   ): Promise<void>;
 }
 
+// ----------------------------
+// Application Lifecycle hooks
+// ----------------------------
+
+/**
+ * `onGatewayReplaceSchema` is an application lifeycle hook will be triggered every time the periodic gateway refresh builds a new schema. It is called just before the old schema is replaced with the new one.
+ * This hook will only be triggered in gateway mode. It has the following parameters:
+ *  - `instance` - The gateway server `FastifyInstance` (this contains the old schema).
+ *  - `schema` - The new schema that has been built from the gateway refresh.
+ */
+export interface onGatewayReplaceSchemaHookHandler {
+  (
+    instance: FastifyInstance,
+    schema: GraphQLSchema
+  ): Promise<void>;
+}
+
 interface ServiceConfig {
   setSchema: (schema: string) => ServiceConfig;
 }
@@ -328,6 +345,16 @@ interface MercuriusPlugin {
    * This hook will only be triggered when subscriptions are enabled.
    */
   addHook<TContext = MercuriusContext>(name: 'onSubscriptionEnd', hook: onSubscriptionEndHookHandler<TContext>): void;
+
+  // Application lifecycle addHooks
+
+  /**
+   * `onGatewayReplaceSchema` is an application lifeycle hook will be triggered every time the periodic gateway refresh builds a new schema. It is called just before the old schema is replaced with the new one.
+   * This hook will only be triggered in gateway mode. It has the following parameters:
+   *  - `instance` - The gateway server `FastifyInstance` (this contains the old schema).
+   *  - `schema` - The new schema that has been built from the gateway refresh.
+   */
+  addHook(name: 'onGatewayReplaceSchema', hook: onGatewayReplaceSchemaHookHandler): void;
 }
 
 interface QueryRequest {

--- a/index.d.ts
+++ b/index.d.ts
@@ -208,7 +208,7 @@ export interface onSubscriptionEndHookHandler<TContext = MercuriusContext> {
 // ----------------------------
 
 /**
- * `onGatewayReplaceSchema` is an application lifeycle hook will be triggered every time the periodic gateway refresh builds a new schema. It is called just before the old schema is replaced with the new one.
+ * `onGatewayReplaceSchema` is an application lifeycle hook. When the Gateway service obtains new versions of federated schemas within a defined polling interval, the `onGatewayReplaceSchema` hook will be triggered every time a new schema is built. It is called just before the old schema is replaced with the new one.
  * This hook will only be triggered in gateway mode. It has the following parameters:
  *  - `instance` - The gateway server `FastifyInstance` (this contains the old schema).
  *  - `schema` - The new schema that has been built from the gateway refresh.
@@ -349,7 +349,7 @@ interface MercuriusPlugin {
   // Application lifecycle addHooks
 
   /**
-   * `onGatewayReplaceSchema` is an application lifeycle hook will be triggered every time the periodic gateway refresh builds a new schema. It is called just before the old schema is replaced with the new one.
+   * `onGatewayReplaceSchema` is an application lifeycle hook. When the Gateway service obtains new versions of federated schemas within a defined polling interval, the `onGatewayReplaceSchema` hook will be triggered every time a new schema is built. It is called just before the old schema is replaced with the new one.
    * This hook will only be triggered in gateway mode. It has the following parameters:
    *  - `instance` - The gateway server `FastifyInstance` (this contains the old schema).
    *  - `schema` - The new schema that has been built from the gateway refresh.

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -1,8 +1,16 @@
 'use strict'
 
-const { hooksRunner, preExecutionHooksRunner, preGatewayExecutionHooksRunner, gatewayHookRunner, hookRunner, preParsingHookRunner, onResolutionHookRunner, onEndHookRunner } = require('./hooks')
+const { hooksRunner, preExecutionHooksRunner, preGatewayExecutionHooksRunner, gatewayHookRunner, hookRunner, preParsingHookRunner, onResolutionHookRunner, onEndHookRunner, onGatewayReplaceSchemaHookRunner } = require('./hooks')
 const { addErrorsToContext } = require('./errors')
 const { print } = require('graphql')
+
+async function onGatewayReplaceSchemaHandler (context, data) {
+  await hooksRunner(
+    context.onGatewayReplaceSchema,
+    onGatewayReplaceSchemaHookRunner,
+    data
+  )
+}
 
 async function preParsingHandler (request) {
   await hooksRunner(
@@ -106,5 +114,6 @@ module.exports = {
   preSubscriptionExecutionHandler,
   preGatewaySubscriptionExecutionHandler,
   onSubscriptionResolutionHandler,
-  onSubscriptionEndHandler
+  onSubscriptionEndHandler,
+  onGatewayReplaceSchemaHandler
 }

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const applicationHooks = [
-  // TODO: identify other application hooks
   'onGatewayReplaceSchema'
 ]
 const lifecycleHooks = [

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -1,5 +1,9 @@
 'use strict'
 
+const applicationHooks = [
+  // TODO: identify other application hooks
+  'onGatewayReplaceSchema'
+]
 const lifecycleHooks = [
   'preParsing',
   'preValidation',
@@ -12,6 +16,7 @@ const lifecycleHooks = [
   'onSubscriptionResolution',
   'onSubscriptionEnd'
 ]
+const supportedHooks = lifecycleHooks.concat(applicationHooks)
 const { MER_ERR_HOOK_INVALID_TYPE, MER_ERR_HOOK_INVALID_HANDLER, MER_ERR_HOOK_UNSUPPORTED_HOOK } = require('./errors')
 
 function Hooks () {
@@ -25,12 +30,13 @@ function Hooks () {
   this.preGatewaySubscriptionExecution = []
   this.onSubscriptionResolution = []
   this.onSubscriptionEnd = []
+  this.onGatewayReplaceSchema = []
 }
 
 Hooks.prototype.validate = function (hook, fn) {
   if (typeof hook !== 'string') throw new MER_ERR_HOOK_INVALID_TYPE()
   if (typeof fn !== 'function') throw new MER_ERR_HOOK_INVALID_HANDLER()
-  if (lifecycleHooks.indexOf(hook) === -1) {
+  if (supportedHooks.indexOf(hook) === -1) {
     throw new MER_ERR_HOOK_UNSUPPORTED_HOOK(hook)
   }
 }
@@ -38,6 +44,14 @@ Hooks.prototype.validate = function (hook, fn) {
 Hooks.prototype.add = function (hook, fn) {
   this.validate(hook, fn)
   this[hook].push(fn)
+}
+
+function assignApplicationLifecycleHooksToContext (hooks, context) {
+  const contextHooks = {
+    onGatewayReplaceSchema: null
+  }
+  if (hooks.onGatewayReplaceSchema.length > 0) contextHooks.onGatewayReplaceSchema = hooks.onGatewayReplaceSchema.slice()
+  return Object.assign(contextHooks, context)
 }
 
 function assignLifeCycleHooksToContext (hooks, context) {
@@ -132,9 +146,14 @@ function onEndHookRunner (fn, request) {
   return fn(request.context)
 }
 
+function onGatewayReplaceSchemaHookRunner (fn, data) {
+  return fn(data.instance, data.schema)
+}
+
 module.exports = {
   Hooks,
   assignLifeCycleHooksToContext,
+  assignApplicationLifecycleHooksToContext,
   hooksRunner,
   preExecutionHooksRunner,
   hookRunner,
@@ -143,5 +162,5 @@ module.exports = {
   preParsingHookRunner,
   onResolutionHookRunner,
   onEndHookRunner,
-  lifecycleHooks
+  onGatewayReplaceSchemaHookRunner
 }

--- a/test/gateway/application-hooks.js
+++ b/test/gateway/application-hooks.js
@@ -1,0 +1,203 @@
+'use strict'
+
+const { test } = require('tap')
+const FakeTimers = require('@sinonjs/fake-timers')
+const { GraphQLSchema } = require('graphql')
+const { promisify } = require('util')
+const Fastify = require('fastify')
+const GQL = require('../..')
+const buildFederationSchema = require('../../lib/federation')
+
+const immediate = promisify(setImmediate)
+
+// ----------------------
+// onGatewayReplaceSchema
+// ----------------------
+test('onGatewayReplaceSchema - polling interval with a new schema should trigger onGatewayReplaceSchema hook', async (t) => {
+  t.plan(2)
+
+  const clock = FakeTimers.install({
+    shouldAdvanceTime: true,
+    advanceTimeDelta: 40
+  })
+  t.teardown(() => clock.uninstall())
+
+  const resolvers = {
+    Query: {
+      me: (root, args, context, info) => user
+    },
+    User: {
+      __resolveReference: (user, args, context, info) => user
+    }
+  }
+
+  const user = {
+    id: 'u1',
+    name: 'John',
+    lastName: 'Doe'
+  }
+
+  const userService = Fastify()
+  const gateway = Fastify()
+  t.teardown(async () => {
+    await gateway.close()
+    await userService.close()
+  })
+
+  userService.register(GQL, {
+    schema: `
+      extend type Query {
+        me: User
+      }
+
+      type User @key(fields: "id") {
+        id: ID!
+        name: String!
+      }
+    `,
+    resolvers: resolvers,
+    federationMetadata: true
+  })
+
+  await userService.listen(0)
+
+  const userServicePort = userService.server.address().port
+
+  await gateway.register(GQL, {
+    gateway: {
+      services: [
+        {
+          name: 'user',
+          url: `http://localhost:${userServicePort}/graphql`
+        }
+      ],
+      pollingInterval: 2000
+    }
+  })
+
+  gateway.graphql.addHook('onGatewayReplaceSchema', async (instance, schema) => {
+    t.type(instance, 'object')
+    t.type(schema, GraphQLSchema)
+  })
+
+  userService.graphql.replaceSchema(
+    buildFederationSchema(`
+      extend type Query {
+        me: User
+      }
+
+      type User @key(fields: "id") {
+        id: ID!
+        name: String!
+        lastName: String!
+      }
+    `)
+  )
+  userService.graphql.defineResolvers(resolvers)
+
+  await clock.tickAsync(2000)
+
+  // We need the event loop to actually spin twice to
+  // be able to propagate the change
+  await immediate()
+  await immediate()
+})
+
+test('onGatewayReplaceSchema - should log an error should any errors occur in the hook', async (t) => {
+  t.plan(2)
+
+  const clock = FakeTimers.install({
+    shouldAdvanceTime: true,
+    advanceTimeDelta: 40
+  })
+  t.teardown(() => clock.uninstall())
+
+  const resolvers = {
+    Query: {
+      me: (root, args, context, info) => user
+    },
+    User: {
+      __resolveReference: (user, args, context, info) => user
+    }
+  }
+
+  const user = {
+    id: 'u1',
+    name: 'John',
+    lastName: 'Doe'
+  }
+
+  const userService = Fastify()
+  const gateway = Fastify()
+  t.teardown(async () => {
+    await gateway.close()
+    await userService.close()
+  })
+
+  userService.register(GQL, {
+    schema: `
+      extend type Query {
+        me: User
+      }
+
+      type User @key(fields: "id") {
+        id: ID!
+        name: String!
+      }
+    `,
+    resolvers: resolvers,
+    federationMetadata: true
+  })
+
+  await userService.listen(0)
+
+  const userServicePort = userService.server.address().port
+
+  await gateway.register(GQL, {
+    gateway: {
+      services: [
+        {
+          name: 'user',
+          url: `http://localhost:${userServicePort}/graphql`
+        }
+      ],
+      pollingInterval: 2000
+    }
+  })
+
+  gateway.graphql.addHook('onGatewayReplaceSchema', async (instance, schema) => {
+    t.ok('trigger error')
+    throw new Error('kaboom')
+  })
+
+  gateway.graphql.addHook('onGatewayReplaceSchema', async (instance, schema) => {
+    t.fail('should not be called')
+  })
+
+  // Override gateway error logger
+  gateway.log.error = (error) => {
+    t.same(error, new Error('kaboom'))
+  }
+
+  userService.graphql.replaceSchema(
+    buildFederationSchema(`
+      extend type Query {
+        me: User
+      }
+
+      type User @key(fields: "id") {
+        id: ID!
+        name: String!
+        lastName: String!
+      }
+    `)
+  )
+  userService.graphql.defineResolvers(resolvers)
+
+  await clock.tickAsync(2000)
+
+  // We need the event loop to actually spin twice to
+  // be able to propagate the change
+  await immediate()
+  await immediate()
+})

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -27,11 +27,11 @@ const resolvers = {
 
 const query = '{ add(x: 2, y: 2) }'
 
-function createTestServer (t, customResolvers = resolvers) {
+function createTestServer (t, customResolvers = resolvers, opts = {}) {
   const app = Fastify()
   t.teardown(() => app.close())
 
-  app.register(GQL, { schema, resolvers: customResolvers })
+  app.register(GQL, { schema, resolvers: customResolvers, ...opts })
 
   return app
 }
@@ -158,6 +158,77 @@ test('hooks validation should handle invalid hook handlers', async t => {
   } catch (e) {
     t.equal(e.code, 'MER_ERR_HOOK_INVALID_HANDLER')
     t.equal(e.message, 'The hook callback must be a function')
+  }
+})
+
+test('hooks should trigger when JIT is enabled', async t => {
+  t.plan(28)
+  const app = await createTestServer(t, resolvers, { jit: 1 })
+
+  app.graphql.addHook('preParsing', async function (schema, source, context) {
+    await immediate()
+    t.type(schema, GraphQLSchema)
+    t.equal(source, query)
+    t.type(context, 'object')
+    t.ok('preParsing called')
+  })
+
+  // preValidation is not triggered a second time
+  app.graphql.addHook('preValidation', async function (schema, document, context) {
+    await immediate()
+    t.type(schema, GraphQLSchema)
+    t.same(document, parse(query))
+    t.type(context, 'object')
+    t.ok('preValidation called')
+  })
+
+  app.graphql.addHook('preExecution', async function (schema, document, context) {
+    await immediate()
+    t.type(schema, GraphQLSchema)
+    t.same(document, parse(query))
+    t.type(context, 'object')
+    t.ok('preExecution called')
+  })
+
+  app.graphql.addHook('preGatewayExecution', async function (schema, document, context) {
+    t.fail('this should not be called')
+  })
+
+  app.graphql.addHook('onResolution', async function (execution, context) {
+    await immediate()
+    t.type(execution, 'object')
+    t.type(context, 'object')
+    t.ok('onResolution called')
+  })
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      url: '/graphql',
+      body: JSON.stringify({ query })
+    })
+
+    t.same(JSON.parse(res.body), {
+      data: {
+        add: 4
+      }
+    })
+  }
+
+  {
+    const res = await app.inject({
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      url: '/graphql',
+      body: JSON.stringify({ query })
+    })
+
+    t.same(JSON.parse(res.body), {
+      data: {
+        add: 4
+      }
+    })
   }
 })
 

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -1,13 +1,14 @@
+import { expectAssignable } from 'tsd'
 /* eslint-disable no-unused-expressions */
 import { EventEmitter } from 'events'
 // eslint-disable-next-line no-unused-vars
-import Fastify, { FastifyReply, FastifyRequest } from 'fastify'
+import Fastify, { FastifyReply, FastifyRequest, FastifyInstance } from 'fastify'
 // eslint-disable-next-line no-unused-vars
 import { Readable } from 'stream'
 // eslint-disable-next-line no-unused-vars
-import mercurius, { MercuriusOptions, IResolvers } from '../..'
+import mercurius, { MercuriusOptions, IResolvers, MercuriusContext, MercuriusServiceMetadata } from '../..'
 // eslint-disable-next-line no-unused-vars
-import { ValidationContext, ValidationRule } from 'graphql'
+import { DocumentNode, ExecutionResult, GraphQLSchema, ValidationContext, ValidationRule } from 'graphql'
 import { makeExecutableSchema } from '@graphql-tools/schema'
 import { mapSchema } from '@graphql-tools/utils'
 import mq from 'mqemitter'
@@ -467,15 +468,21 @@ query hello {
 `)
 
 app.graphql.addHook('preParsing', async function (schema, source, context) {
-  console.log('preParsing called')
+  expectAssignable<GraphQLSchema>(schema)
+  expectAssignable<string>(source)
+  expectAssignable<MercuriusContext>(context)
 })
 
 app.graphql.addHook('preValidation', async function (schema, document, context) {
-  console.log('preValidation called')
+  expectAssignable<GraphQLSchema>(schema)
+  expectAssignable<DocumentNode>(document)
+  expectAssignable<MercuriusContext>(context)
 })
 
 app.graphql.addHook('preExecution', async function (schema, document, context) {
-  console.log('preExecution called')
+  expectAssignable<GraphQLSchema>(schema)
+  expectAssignable<DocumentNode>(document)
+  expectAssignable<MercuriusContext>(context)
   return {
     document,
     errors: [
@@ -485,7 +492,9 @@ app.graphql.addHook('preExecution', async function (schema, document, context) {
 })
 
 app.graphql.addHook('preGatewayExecution', async function (schema, document, context) {
-  console.log('preGatewayExecution called')
+  expectAssignable<GraphQLSchema>(schema)
+  expectAssignable<DocumentNode>(document)
+  expectAssignable<MercuriusContext>(context)
   return {
     document,
     errors: [
@@ -494,35 +503,56 @@ app.graphql.addHook('preGatewayExecution', async function (schema, document, con
   }
 })
 
+// GraphQL Request lifecycle hooks
 app.graphql.addHook('onResolution', async function (execution, context) {
-  console.log('onResolution called')
+  expectAssignable<ExecutionResult>(execution)
+  expectAssignable<MercuriusContext>(context)
 })
 
 app.graphql.addHook('preSubscriptionParsing', async function (schema, source, context) {
-  console.log('preSubscriptionParsing called')
+  expectAssignable<GraphQLSchema>(schema)
+  expectAssignable<string>(source)
+  expectAssignable<MercuriusContext>(context)
 })
 
 app.graphql.addHook('preSubscriptionExecution', async function (schema, document, context) {
-  console.log('preSubscriptionExecution called')
+  expectAssignable<GraphQLSchema>(schema)
+  expectAssignable<DocumentNode>(document)
+  expectAssignable<MercuriusContext>(context)
 })
 
 app.graphql.addHook('preGatewaySubscriptionExecution', async function (schema, document, context) {
-  console.log('preGatewaySubscriptionExecution called')
+  expectAssignable<GraphQLSchema>(schema)
+  expectAssignable<DocumentNode>(document)
+  expectAssignable<MercuriusContext>(context)
 })
 
 app.graphql.addHook('onSubscriptionResolution', async function (execution, context) {
-  console.log('onSubscriptionResolution called')
+  expectAssignable<ExecutionResult>(execution)
+  expectAssignable<MercuriusContext>(context)
 })
 
 app.graphql.addHook('onSubscriptionEnd', async function (context) {
-  console.log('onSubscriptionEnd called')
+  expectAssignable<MercuriusContext>(context)
 })
 
 // Hooks containing service metadata
 app.graphql.addHook('preGatewayExecution', async function (schema, document, context, service) {
-  console.log('preGatewayExecution called')
+  expectAssignable<GraphQLSchema>(schema)
+  expectAssignable<DocumentNode>(document)
+  expectAssignable<MercuriusContext>(context)
+  expectAssignable<MercuriusServiceMetadata>(service)
 })
 
 app.graphql.addHook('preGatewaySubscriptionExecution', async function (schema, document, context, service) {
-  console.log('preGatewaySubscriptionExecution called')
+  expectAssignable<GraphQLSchema>(schema)
+  expectAssignable<DocumentNode>(document)
+  expectAssignable<MercuriusContext>(context)
+  expectAssignable<MercuriusServiceMetadata>(service)
+})
+
+// GraphQL Application lifecycle hooks
+app.graphql.addHook('onGatewayReplaceSchema', async function (instance, schema) {
+  expectAssignable<FastifyInstance>(instance)
+  expectAssignable<GraphQLSchema>(schema)
 })


### PR DESCRIPTION
This PR adds a new application lifecycle hook as a result of this discussion in Mercurius Auth: https://github.com/mercurius-js/auth/pull/3#discussion_r615405536

It adds the following:
 - Add `onGatewayReplaceSchema` application lifecycle hook
 - Fixes an issue where the `preExecution` hook was not run when the query has been jit'd. I found this when improving the performance in the Mercurius Auth benchmarks

It also includes a fix for the slow `rewriteHeaders` tests which were taking ~8s to run. I've noticed that `pollingInterval` and `remote-services` tests also take a long time. Looking at the code, I think it's to do with the way the gateway is closed when it errors upon building the schema - however I need to confirm this. Very happy to take a long at this in a follow up PR when I have some spare time next week! :)