### PR TITLE
fix #467

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -292,9 +292,7 @@ module.exports = async function (app, opts) {
       ))
     } else {
       // Regular query
-      const data = execute(request.body, request, reply)
-
-      return data
+      return execute(request.body, request, reply)
     }
   })
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -40,12 +40,17 @@ const responseProperties = {
         extensions: {
           type: 'object',
           properties: {
+
             code: { type: 'string' }
           },
           additionalProperties: true
         }
       }
     }
+  },
+  extensions: {
+    type: 'object',
+    additionalProperties: true
   }
 }
 
@@ -287,7 +292,9 @@ module.exports = async function (app, opts) {
       ))
     } else {
       // Regular query
-      return execute(request.body, request, reply)
+      const data = execute(request.body, request, reply)
+
+      return data
     }
   })
 

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -718,3 +718,39 @@ test('onResolution hooks should be able to put values onto the context', async t
     }
   })
 })
+
+test('onResolution hooks should be able to add extensions data', async t => {
+  t.plan(5)
+
+  const app = await createTestServer(t)
+
+  app.graphql.addHook('onResolution', async (execution, context) => {
+    t.type(execution, 'object')
+
+    execution.extensions = {
+      extensionKey: 'extensionValue'
+    }
+  })
+
+  app.graphql.addHook('onResolution', async (execution, context) => {
+    t.type(execution, 'object')
+    t.type(execution.extensions, 'object')
+    t.equal(execution.extensions.extensionKey, 'extensionValue')
+  })
+
+  const res = await app.inject({
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    url: '/graphql',
+    body: JSON.stringify({ query })
+  })
+
+  t.same(JSON.parse(res.body), {
+    data: {
+      add: 4
+    },
+    extensions: {
+      extensionKey: 'extensionValue'
+    }
+  })
+})


### PR DESCRIPTION
fix #467 

Fixes the issue where extensions data wouldn't follow along in the GraphQL response.

The issue had to do with the `responseProperties` object in `routes.js` not having a field for the extensions, causing it to be omitted.