### PR TITLE
Add Mercurius auth plugin documentation links

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -2,6 +2,16 @@
 
 Related plugins for mercurius
 
+- [mercurius-auth](#mercurius-auth)
+- [mercurius-upload](#mercurius-upload)
+- [altair-fastify-plugin](#altair-fastify-plugin)
+
+## mercurius-auth
+
+Mercurius Auth is a plugin for [Mercurius](https://mercurius.dev) that adds configurable Authentication and Authorization support.
+
+Check the [`mercurius-auth` documentation](https://github.com/mercurius-js/auth) for detailed usage.
+
 ## mercurius-upload
 
 Implementation of [graphql-upload](https://github.com/jaydenseric/graphql-upload) for File upload support.

--- a/docsify/sidebar.md
+++ b/docsify/sidebar.md
@@ -26,6 +26,7 @@
   * [Testing](/docs/integrations/mercurius-integration-testing)
   * [Tracing - OpenTelemetry](/docs/integrations/open-telemetry)
 * [Related Plugins](/docs/plugins)
+  * [mercurius-auth](/docs/plugins#mercurius-auth)
   * [mercurius-upload](/docs/plugins#mercurius-upload)
   * [altair-fastify-plugin](/docs/plugins#altair-fastify-plugin)
 * [Protocol Extensions](/docs/protocol-extension)


### PR DESCRIPTION
This PR adds the doc links for the `mercurius-auth` plugin. Have tested locally, and all looks okay from a docs generation point of view:

<img width="849" alt="Screenshot 2021-05-02 at 17 59 25" src="https://user-images.githubusercontent.com/31290910/116821052-23c91680-ab70-11eb-8975-75d9cec76921.png">
