### PR TITLE
fix(types): add context to rewrite headers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -382,7 +382,7 @@ export interface MercuriusGatewayService {
   wsUrl?: string;
   mandatory?: boolean;
   initHeaders?: (() => OutgoingHttpHeaders | Promise<OutgoingHttpHeaders>) | OutgoingHttpHeaders;
-  rewriteHeaders?: <TContext = MercuriusContext>(headers: IncomingHttpHeaders, context: TContext) => OutgoingHttpHeaders;
+  rewriteHeaders?: <TContext extends MercuriusContext = MercuriusContext>(headers: IncomingHttpHeaders, context: TContext) => OutgoingHttpHeaders;
   connections?: number;
   keepAliveMaxTimeout?: number;
   rejectUnauthorized?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -382,7 +382,7 @@ export interface MercuriusGatewayService {
   wsUrl?: string;
   mandatory?: boolean;
   initHeaders?: (() => OutgoingHttpHeaders | Promise<OutgoingHttpHeaders>) | OutgoingHttpHeaders;
-  rewriteHeaders?: (headers: IncomingHttpHeaders) => OutgoingHttpHeaders;
+  rewriteHeaders?: <TContext = MercuriusContext>(headers: IncomingHttpHeaders, context: TContext) => OutgoingHttpHeaders;
   connections?: number;
   keepAliveMaxTimeout?: number;
   rejectUnauthorized?: boolean;

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -245,7 +245,8 @@ gateway.register(mercurius, {
         keepAliveMaxTimeout: 10000,
         mandatory: true,
         rejectUnauthorized: true,
-        rewriteHeaders: (headers) => {
+        rewriteHeaders: (headers, context) => {
+          expectAssignable<MercuriusContext>(context)
           return {
             authorization: headers.authorization
           }


### PR DESCRIPTION
Follow-up of https://github.com/mercurius-js/mercurius/pull/454. Added the respective typing to `rewriteHeaders`.