### PR TITLE
Improve test stability

### DIFF
--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -187,6 +187,9 @@ async function buildGateway (gatewayOpts, app) {
   }, [])
 
   if (serviceSDLs.length < 1) {
+    for (const service of Object.values(serviceMap)) {
+      service.close()
+    }
     throw new MER_ERR_GQL_GATEWAY_INIT('No valid service SDLs were provided')
   }
 

--- a/test/gateway/remote-services.js
+++ b/test/gateway/remote-services.js
@@ -27,7 +27,7 @@ async function createRemoteService (schema) {
   return [service, service.server.address().port]
 }
 
-test('Throws an Error if there are no valid services', async (t) => {
+test('Throws an Error and cleans up service connections correctly if there are no valid services', { timeout: 4000 }, async (t) => {
   const [service, servicePort] = await createRemoteService(invalidSchema)
 
   const gateway = Fastify()

--- a/test/subscription-connection.js
+++ b/test/subscription-connection.js
@@ -290,11 +290,13 @@ test('subscription connection extends context with onConnect return value', asyn
 })
 
 test('subscription connection send GQL_ERROR message if connectionInit extension is defined and onConnect returns a falsy value', async (t) => {
+  t.plan(1)
+
   const sc = new SubscriptionConnection({
     on () { },
     close () { },
     send (message) {
-      t.sames(JSON.parse(message), {
+      t.same(JSON.parse(message), {
         id: 1,
         type: 'error',
         payload: 'Forbidden'
@@ -352,11 +354,13 @@ test('subscription connection does not create subscription if connectionInit ext
 })
 
 test('subscription connection send GQL_ERROR on unknown extension', async (t) => {
+  t.plan(2)
+
   const sc = new SubscriptionConnection({
     on () { },
     close () { },
     send (message) {
-      t.sames(JSON.parse(message), {
+      t.same(JSON.parse(message), {
         id: 1,
         type: 'error',
         payload: 'Unknown extension unknown'


### PR DESCRIPTION
Fixes: https://github.com/mercurius-js/mercurius/issues/476

The intermittent `pollingInterval.js` failures include two fixes:
 - One to prevent a race condition on Windows when writing a `connection_init` and `start` at the same time.
 - One to prevent a race condition on Windows where the mutation was called before the subscription was created.

For reducing the time taken for the `remote-services.js` test to run, I was wasn't able to work out a test case for this without a large code refactor. I've added a timeout for this test to capture the fact that the service connections are now being cleaned up correctly - let me know if you have any ideas on this! :)

I've run the tests on repeat ~60x and found no failures, so am fairly confident this catches the intermittent failures.