### PR TITLE
refactor(gateway): defineResolvers now properly handles value types

### DIFF
--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -151,7 +151,7 @@ function defineResolvers (schema, typeToServiceMap, serviceMap, typeFieldsToServ
              * If there is no service for the type, it is a query, mutation or subscription
              */
             let service = serviceMap[serviceForFieldType]
-            if (typeof service === 'undefined') {
+            if (!service) {
               /**
                * If the value type is the return type of a query, subscription or mutation, its service is undefined, e.g. for
                * extend type Query {

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -164,14 +164,14 @@ function defineResolvers (schema, typeToServiceMap, serviceMap, typeFieldsToServ
             }
             if (type.name === 'Subscription') {
               field.subscribe = makeResolver({
-                service: service,
+                service,
                 createOperation: createQueryOperation,
                 isQuery: true,
                 isSubscription: true
               })
             } else {
               field.resolve = makeResolver({
-                service: service,
+                service,
                 createOperation: createQueryOperation,
                 transformData: response => response.json.data[fieldName],
                 isQuery: true

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -37,23 +37,41 @@ function isDefaultType (type) {
 /**
  * The gateway resolver methods are responsible to delegate certain parts of the query to a service.
  *
- * For every type in the schema - defined by services - it checks each field to decide what kind of resolver it needs.
- * This is done by getting the service name of the current type and comparing it to the return type of the field when
- * it is not a Scalar type (Scalar type fields do not need resolvers). Only when the two services are not the same it is
- * needed to add a resolver function for the field.
+ * For each type in the schema defined by the services, it checks each field to decide if it needs a resolver and if so,
+ * what kind of resolver. This is done by getting the current type, its service name (if defined) and the service name
+ * of the field type (if defined). The respective services can be undefined if the field type is a value type or the
+ * type is query, mutation or subscription.
  *
- * There are 3 options:
- *  - Query field resolver: when the service of the type is null
- *  - Reference entity resolver: when the service of type defined the field on the type
- *  - Field entity resolver: when the field was added through type extension in the service of the field's type
+ * While derivation logic is documented inline, the following example shall provide an overview.
  *
- * Example
  *
- * Service 1
+ * Service 1 (User Service)
  *
  * extend Query {
- *   # assign query field resolver
- *   me: User
+ *   # assign query field resolver to retrieve the user from user service
+ *   me: User!
+ *   # assign query field resolver to retrieve the user connection from user service
+ *   users: UserConnection!
+ *   # assign a query field resolver to retrieve the service info (which is a value type) from the user service
+ *   userServiceInfo: ServiceInfo!
+ * }
+ *
+ * type ServiceInfo {
+ *   name: String!
+ * }
+ *
+ * type UserConnection {
+ *   # PageInfo is defined in both services, hence a value type, and resolved from the parent
+ *   pageInfo: PageInfo!
+ *   edges: [UserEdge!]!
+ * }
+ *
+ * type PageInfo {
+ *   hasNextPage: Boolean
+ * }
+ *
+ * type UserEdge {
+ *   node: User!
  * }
  *
  * type User @key(fields: "id") {
@@ -61,19 +79,45 @@ function isDefaultType (type) {
  *   name: String
  * }
  *
- * Service 2
+ *
+ * Service 2 (Post Service)
+ *
+ * extend type Query {
+ *   # assign query field resolver to retrieve posts from post service
+ *   posts: PostConnection!
+ *   # assign a query field resolver to retrieve the service info (which is a value type) from the post service
+ *   postServiceInfo: ServiceInfo!
+ * }
+ *
+ * type ServiceInfo {
+ *   name: String!
+ * }
+ *
+ * type PostConnection {
+ *   # PageInfo is defined in both services, hence a value type, and resolved from the parent
+ *   pageInfo: PageInfo!
+ *   edges: [PostEdge!]!
+ * }
+ *
+ * type PageInfo {
+ *   hasNextPage: Boolean
+ * }
+ *
+ * type PostEdge {
+ *   node: Post!
+ * }
  *
  * type Post @key(fields: "id") {
  *   id: ID!
  *   title: String
  *   content: String
- *   # assign reference entity field resolver
+ *   # assign reference entity field resolver to retrieve author from user service
  *   author: User
  * }
  *
  * extend type User @key(fields: "id") {
  *   id: ID! @external
- *   # assign field entity resolver
+ *   # assign field entity resolver to enable querying posts of a user from the post service
  *   posts: [Post]
  * }
  */
@@ -96,10 +140,10 @@ function defineResolvers (schema, typeToServiceMap, serviceMap, typeFieldsToServ
             (serviceForFieldType !== null && serviceForType !== null && serviceForFieldType === serviceForType)
           ) {
             /**
-             * Either there is a service for the type and no service for the field type,
-             * hence the field type is a value type and its not a query / mutation / subscription.
-             * Or there is a service for the type and the field type and it is the same service.
-             * In both cases, we resolve from the parent
+             * We resolve from the parent in two cases:
+             * - Either there is a service for the type and no service for the field type.
+             *   In this case, the field type is a value type and the type is neither a query, mutation nor a subscription.
+             * - Or there is a service for the type and a service for the field type and both refer to the same service.
              */
             field.resolve = (parent, args, context, info) => parent && parent[info.path.key]
           } else if (serviceForType === null) {
@@ -135,7 +179,7 @@ function defineResolvers (schema, typeToServiceMap, serviceMap, typeFieldsToServ
             }
           } else if (serviceForFieldType !== null && serviceForFieldType !== serviceForType) {
             /**
-             * If there is no service for the field type but a service for the type and it is not the same,
+             * If there is a service for the field type and a service for the type and it is not the same service,
              * it is an entity
              */
             // check if the field is default field of the type

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -77,7 +77,7 @@ function isDefaultType (type) {
  *   posts: [Post]
  * }
  */
-function defineResolvers (schema, typeToServiceMap, serviceMap, typeFieldsToService, valueTypes) {
+function defineResolvers (schema, typeToServiceMap, serviceMap, typeFieldsToService) {
   const types = schema.getTypeMap()
 
   for (const type of Object.values(types)) {
@@ -90,58 +90,82 @@ function defineResolvers (schema, typeToServiceMap, serviceMap, typeFieldsToServ
         const fieldName = field.name
         if (!isScalarType(fieldType)) {
           const serviceForFieldType = typeToServiceMap[fieldType]
-
-          if (serviceForFieldType !== serviceForType && !valueTypes.includes(`${fieldType.name}`)) {
-            /* istanbul ignore else */
-            if (serviceForType === null) {
-              // Either query, mutation, subscription
-              if (type.name === 'Subscription') {
-                field.subscribe = makeResolver({
-                  service: serviceMap[serviceForFieldType],
-                  createOperation: createQueryOperation,
-                  isQuery: true,
-                  isSubscription: true
-                })
-              } else {
-                field.resolve = makeResolver({
-                  service: serviceMap[serviceForFieldType],
-                  createOperation: createQueryOperation,
-                  transformData: response => response.json.data[fieldName],
-                  isQuery: true
-                })
-              }
-            } else if (!fieldType.astNode || fieldType.astNode.kind !== Kind.INTERFACE_TYPE_DEFINITION) {
-              // check if the field is default field of the type
-              if (serviceMap[serviceForType].typeMap[type.name].has(fieldName)) {
-                // Check if field is nullable
-                const isNonNull = field.astNode.type.kind === Kind.NON_NULL_TYPE
-                const leafKind = isNonNull ? field.astNode.type.type.kind : field.astNode.type.kind
-
-                if (leafKind === Kind.LIST_TYPE) {
-                  field.resolve = makeResolver({
-                    service: serviceMap[serviceForFieldType],
-                    createOperation: createEntityReferenceResolverOperation,
-                    transformData: response => response ? response.json.data._entities : (isNonNull ? [] : null),
-                    isReference: true
-                  })
-                } else {
-                  field.resolve = makeResolver({
-                    service: serviceMap[serviceForFieldType],
-                    createOperation: createEntityReferenceResolverOperation,
-                    transformData: response => response.json.data._entities[0],
-                    isReference: true
-                  })
-                }
-              } else {
-                field.resolve = makeResolver({
-                  service: serviceMap[serviceForFieldType],
-                  createOperation: createFieldResolverOperation,
-                  transformData: response => response.json.data._entities[0][fieldName]
-                })
-              }
-            }
-          } else {
+          /* istanbul ignore else */
+          if (
+            (serviceForFieldType === null && serviceForType !== null) ||
+            (serviceForFieldType !== null && serviceForType !== null && serviceForFieldType === serviceForType)
+          ) {
+            /**
+             * Either there is a service for the type and no service for the field type,
+             * hence the field type is a value type and its not a query / mutation / subscription.
+             * Or there is a service for the type and the field type and it is the same service.
+             * In both cases, we resolve from the parent
+             */
             field.resolve = (parent, args, context, info) => parent && parent[info.path.key]
+          } else if (serviceForType === null) {
+            /**
+             * If there is no service for the type, it is a query, mutation or subscription
+             */
+            let service = serviceMap[serviceForFieldType]
+            if (typeof service === 'undefined') {
+              /**
+               * If the value type is the return type of a query, subscription or mutation, its service is undefined, e.g. for
+               * extend type Query {
+               *    userServiceInfo: SomeReturnType!
+               * }
+               * where SomeReturnType is a value type.
+               * In these cases, we get the service from the typeFieldsToService map.
+               */
+              service = serviceMap[typeFieldsToService[`${type}-${fieldName}`]]
+            }
+            if (type.name === 'Subscription') {
+              field.subscribe = makeResolver({
+                service: service,
+                createOperation: createQueryOperation,
+                isQuery: true,
+                isSubscription: true
+              })
+            } else {
+              field.resolve = makeResolver({
+                service: service,
+                createOperation: createQueryOperation,
+                transformData: response => response.json.data[fieldName],
+                isQuery: true
+              })
+            }
+          } else if (serviceForFieldType !== null && serviceForFieldType !== serviceForType) {
+            /**
+             * If there is no service for the field type but a service for the type and it is not the same,
+             * it is an entity
+             */
+            // check if the field is default field of the type
+            if (serviceMap[serviceForType].typeMap[type.name].has(fieldName)) {
+              // Check if field is nullable
+              const isNonNull = field.astNode.type.kind === Kind.NON_NULL_TYPE
+              const leafKind = isNonNull ? field.astNode.type.type.kind : field.astNode.type.kind
+
+              if (leafKind === Kind.LIST_TYPE) {
+                field.resolve = makeResolver({
+                  service: serviceMap[serviceForFieldType],
+                  createOperation: createEntityReferenceResolverOperation,
+                  transformData: response => response ? response.json.data._entities : (isNonNull ? [] : null),
+                  isReference: true
+                })
+              } else {
+                field.resolve = makeResolver({
+                  service: serviceMap[serviceForFieldType],
+                  createOperation: createEntityReferenceResolverOperation,
+                  transformData: response => response.json.data._entities[0],
+                  isReference: true
+                })
+              }
+            } else {
+              field.resolve = makeResolver({
+                service: serviceMap[serviceForFieldType],
+                createOperation: createFieldResolverOperation,
+                transformData: response => response.json.data._entities[0][fieldName]
+              })
+            }
           }
         } else if (typeFieldsToService[`${type}-${fieldName}`]) {
           const service = serviceMap[typeFieldsToService[`${type}-${fieldName}`]]
@@ -347,11 +371,11 @@ async function buildGateway (gatewayOpts, app) {
   typeToServiceMap.Subscription = null
 
   const valueTypes = findValueTypes(allTypes)
-  for (const typeName in valueTypes) {
-    delete typeToServiceMap[typeName]
+  for (const typeName of valueTypes) {
+    typeToServiceMap[typeName] = null
   }
 
-  defineResolvers(schema, typeToServiceMap, serviceMap, typeFieldsToService, valueTypes)
+  defineResolvers(schema, typeToServiceMap, serviceMap, typeFieldsToService)
 
   return {
     schema,
@@ -419,11 +443,11 @@ async function buildGateway (gatewayOpts, app) {
       typeToServiceMap.Subscription = null
 
       const valueTypes = findValueTypes(allTypes)
-      for (const typeName in valueTypes) {
-        delete typeToServiceMap[typeName]
+      for (const typeName of valueTypes) {
+        typeToServiceMap[typeName] = null
       }
 
-      defineResolvers(schema, typeToServiceMap, serviceMap, typeFieldsToService, valueTypes)
+      defineResolvers(schema, typeToServiceMap, serviceMap, typeFieldsToService)
 
       return schema
     },


### PR DESCRIPTION
Hi,

I realized that the current valueTypes implementation is fundamentally flawed, for example, "top-level" value types were not handled properly. When a mutation/query/subscription returns a value type, it throws `Cannot return null for Mutation.myMutation`.

Hence, I refactored the way the `defineResolvers` function handles non-scalar types.  I added the documentation in-line. It basically uses `serviceForFieldType` and `serviceForType` to derive whether the field should be resolved from the parent, through a query / subscription / mutation or through an entity query.

#499