### PR TITLE
fix: allow scalar subscriptions in gateway

### DIFF
--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -146,12 +146,21 @@ function defineResolvers (schema, typeToServiceMap, serviceMap, typeFieldsToServ
         } else if (typeFieldsToService[`${type}-${fieldName}`]) {
           const service = serviceMap[typeFieldsToService[`${type}-${fieldName}`]]
           if (serviceForType === null) {
-            field.resolve = makeResolver({
-              service,
-              createOperation: createQueryOperation,
-              transformData: response => response.json.data[fieldName],
-              isQuery: true
-            })
+            if (type.name === 'Subscription') {
+              field.subscribe = makeResolver({
+                service,
+                createOperation: createQueryOperation,
+                isQuery: true,
+                isSubscription: true
+              })
+            } else {
+              field.resolve = makeResolver({
+                service,
+                createOperation: createQueryOperation,
+                transformData: response => response.json.data[fieldName],
+                isQuery: true
+              })
+            }
           } else {
             field.resolve = makeResolver({
               service,


### PR DESCRIPTION
Allows using plain scalars in subscriptions in federation gateway instead of having to wrap them in types

Closes #370 