### PR TITLE
Subscription loaders

### DIFF
--- a/index.js
+++ b/index.js
@@ -364,7 +364,10 @@ const plugin = fp(async function (app, opts) {
         if (!reply) {
           throw new MER_ERR_INVALID_OPTS('loaders only work via reply.graphql()')
         }
-        return reply[kLoaders][name]({ obj, params })
+        
+        if (reply[kLoaders] && reply[kLoaders][name]) {
+          return reply[kLoaders][name]({ obj, params })
+        }
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -358,16 +358,18 @@ const plugin = fp(async function (app, opts) {
       app.decorate(kFactory, factory)
     }
 
-    function defineLoader (name) {
+    function defineLoader (name, prop) {
       // async needed because of throw
       return async function (obj, params, { reply }) {
         if (!reply) {
           throw new MER_ERR_INVALID_OPTS('loaders only work via reply.graphql()')
         }
-        
+
         if (reply[kLoaders] && reply[kLoaders][name]) {
           return reply[kLoaders][name]({ obj, params })
         }
+
+        return obj[prop]
       }
     }
 
@@ -377,7 +379,7 @@ const plugin = fp(async function (app, opts) {
       resolvers[typeKey] = {}
       for (const prop of Object.keys(type)) {
         const name = typeKey + '-' + prop
-        resolvers[typeKey][prop] = defineLoader(name)
+        resolvers[typeKey][prop] = defineLoader(name, prop)
         if (typeof type[prop] === 'function') {
           factory.add(name, type[prop])
         } else {

--- a/index.js
+++ b/index.js
@@ -364,7 +364,7 @@ const plugin = fp(async function (app, opts) {
       app.decorate(kSubscriptionFactory, subscriptionFactory)
     }
 
-    function defineLoader (name, prop) {
+    function defineLoader (name) {
       // async needed because of throw
       return async function (obj, params, { reply }) {
         if (!reply) {
@@ -381,7 +381,7 @@ const plugin = fp(async function (app, opts) {
       resolvers[typeKey] = {}
       for (const prop of Object.keys(type)) {
         const name = typeKey + '-' + prop
-        resolvers[typeKey][prop] = defineLoader(name, prop)
+        resolvers[typeKey][prop] = defineLoader(name)
         if (typeof type[prop] === 'function') {
           factory.add(name, type[prop])
           subscriptionFactory.add(name, { cache: false }, type[prop])

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ const {
   MER_ERR_INVALID_METHOD
 } = require('./lib/errors')
 const { Hooks, assignLifeCycleHooksToContext, assignApplicationLifecycleHooksToContext } = require('./lib/hooks')
-const { kLoaders, kFactory, kHooks } = require('./lib/symbols')
+const { kLoaders, kFactory, kSubscriptionFactory, kHooks } = require('./lib/symbols')
 const { preParsingHandler, preValidationHandler, preExecutionHandler, onResolutionHandler, onGatewayReplaceSchemaHandler } = require('./lib/handlers')
 
 function buildCache (opts) {
@@ -345,6 +345,7 @@ const plugin = fp(async function (app, opts) {
   }
 
   let factory
+  let subscriptionFactory
 
   fastifyGraphQl.defineLoaders = function (loaders) {
     if (gateway) {
@@ -358,6 +359,11 @@ const plugin = fp(async function (app, opts) {
       app.decorate(kFactory, factory)
     }
 
+    if (!subscriptionFactory) {
+      subscriptionFactory = new Factory()
+      app.decorate(kSubscriptionFactory, subscriptionFactory)
+    }
+
     function defineLoader (name, prop) {
       // async needed because of throw
       return async function (obj, params, { reply }) {
@@ -365,11 +371,7 @@ const plugin = fp(async function (app, opts) {
           throw new MER_ERR_INVALID_OPTS('loaders only work via reply.graphql()')
         }
 
-        if (reply[kLoaders] && reply[kLoaders][name]) {
-          return reply[kLoaders][name]({ obj, params })
-        }
-
-        return obj[prop]
+        return reply[kLoaders][name]({ obj, params })
       }
     }
 
@@ -382,8 +384,10 @@ const plugin = fp(async function (app, opts) {
         resolvers[typeKey][prop] = defineLoader(name, prop)
         if (typeof type[prop] === 'function') {
           factory.add(name, type[prop])
+          subscriptionFactory.add(name, { cache: false }, type[prop])
         } else {
           factory.add(name, type[prop].opts, type[prop].loader)
+          subscriptionFactory.add(name, Object.assign({}, type[prop].opts, { cache: false }), type[prop].loader)
         }
       }
     }

--- a/lib/subscription-connection.js
+++ b/lib/subscription-connection.js
@@ -18,6 +18,7 @@ const {
 } = require('./subscription-protocol')
 const { MER_ERR_GQL_SUBSCRIPTION_FORBIDDEN, MER_ERR_GQL_SUBSCRIPTION_UNKNOWN_EXTENSION } = require('./errors')
 const { preSubscriptionParsingHandler, onSubscriptionResolutionHandler, preSubscriptionExecutionHandler, onSubscriptionEndHandler } = require('./handlers')
+const { kSubscriptionFactory, kLoaders } = require('./symbols')
 
 module.exports = class SubscriptionConnection {
   constructor (socket, {
@@ -181,6 +182,12 @@ module.exports = class SubscriptionConnection {
     if (this.context.preSubscriptionExecution !== null && typeof schema !== 'undefined') {
       await preSubscriptionExecutionHandler({ schema, document, context })
     }
+
+    let subscriptionLoaders
+    if (this.fastify && this.fastify[kSubscriptionFactory]) {
+      subscriptionLoaders = this.fastify[kSubscriptionFactory]
+    }
+
     const subIter = await subscribe(
       schema,
       document,
@@ -190,6 +197,7 @@ module.exports = class SubscriptionConnection {
         pubsub: sc,
         lruGatewayResolvers: this.lruGatewayResolvers,
         reply: {
+          [kLoaders]: subscriptionLoaders && subscriptionLoaders.create(),
           [kEntityResolvers]: this.entityResolvers,
           request: { headers: {} }
         }

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -3,6 +3,7 @@
 const keys = {
   kLoaders: Symbol('mercurius.loaders'),
   kFactory: Symbol('mercurius.loadersFactory'),
+  kSubscriptionFactory: Symbol('mercurius.subscriptionLoadersFactory'),
   kHooks: Symbol('mercurius.hooks')
 }
 

--- a/test/loaders.js
+++ b/test/loaders.js
@@ -2,6 +2,8 @@
 
 const { test } = require('tap')
 const Fastify = require('fastify')
+const WebSocket = require('ws')
+const mq = require('mqemitter')
 const GQL = require('..')
 
 const dogs = [{
@@ -38,6 +40,10 @@ const schema = `
 
   type Query {
     dogs: [Dog]
+  }
+
+  type Subscription {
+    onPingDog: Dog
   }
 `
 
@@ -540,5 +546,81 @@ test('loaders support custom context', async (t) => {
         }
       }]
     }
+  })
+})
+
+test('undefined loaders shouldnt limit subscription payloads given all necessary data', t => {
+  const app = Fastify()
+  const emitter = mq()
+  t.teardown(() => app.close())
+
+  app.register(GQL, {
+    schema,
+    resolvers: {
+      Subscription: {
+        onPingDog: {
+          subscribe: (_, params, { pubsub }) => pubsub.subscribe('PINGED_DOG')
+        }
+      }
+    },
+    loaders: {
+      Dog: {
+        owner: async () => [owners[0]]
+      }
+    },
+    subscription: {
+      emitter
+    }
+  })
+
+  const expectedDog = dogs[0]
+  expectedDog.owner = owners[dogs[0].name]
+
+  app.listen(0, err => {
+    t.error(err)
+
+    const ws = new WebSocket('ws://localhost:' + (app.server.address()).port + '/graphql', 'graphql-ws')
+    const client = WebSocket.createWebSocketStream(ws, { encoding: 'utf8', objectMode: true })
+    t.teardown(client.destroy.bind(client))
+    client.setEncoding('utf8')
+
+    client.write(JSON.stringify({
+      type: 'connection_init'
+    }))
+
+    client.write(JSON.stringify({
+      id: 1,
+      type: 'start',
+      payload: {
+        query: `
+          subscription {
+            onPingDog {
+              name
+              owner {
+                name
+              }
+            }
+          }
+        `
+      }
+    }))
+
+    client.on('data', chunk => {
+      const data = JSON.parse(chunk)
+
+      if (data.type === 'connection_ack') {
+        app.graphql.pubsub.publish({
+          topic: 'PINGED_DOG',
+          payload: { onPingDog: expectedDog }
+        })
+      } else if (data.id === 1) {
+        t.same(data.payload.data.onPingDog, expectedDog)
+
+        client.end()
+        t.end()
+      } else {
+        t.fail()
+      }
+    })
   })
 })


### PR DESCRIPTION
This PR actually reverts the previous one a bit. The issue before was that if we defined loaders, they weren't passed into subscriptions. This made it so even if we passed through all the required data it would throw an error and overwrite the data given with null.

Now that we have loaders being passed in that isn't a possibility. I tried to force the issue in some tests and do some cheeky stuff like passing `undefined` as a loader but it would error long before getting through loader definition.