### PR TITLE
fix: change context merging behavior

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,7 +184,7 @@ const plugin = fp(async function (app, opts) {
       if (typeof gateway.pollingInterval === 'number') {
         gatewayInterval = setInterval(async () => {
           try {
-            const context = assignApplicationLifecycleHooksToContext(fastifyGraphQl[kHooks], {})
+            const context = assignApplicationLifecycleHooksToContext({}, fastifyGraphQl[kHooks])
             const schema = await gateway.refresh()
             if (schema !== null) {
               // Trigger onGatewayReplaceSchema hook
@@ -254,7 +254,11 @@ const plugin = fp(async function (app, opts) {
   app.decorateReply(graphqlCtx, null)
 
   app.decorateReply('graphql', function (source, context, variables, operationName) {
-    context = Object.assign({ reply: this, app }, context)
+    if (!context) {
+      context = {}
+    }
+
+    context = Object.assign(context, { reply: this, app })
     if (app[kFactory]) {
       this[kLoaders] = factory.create(context)
     }
@@ -424,8 +428,12 @@ const plugin = fp(async function (app, opts) {
   }
 
   async function fastifyGraphQl (source, context, variables, operationName) {
-    context = Object.assign({ app: this, lruGatewayResolvers, errors: null }, context)
-    context = assignLifeCycleHooksToContext(fastifyGraphQl[kHooks], context)
+    if (!context) {
+      context = {}
+    }
+
+    context = Object.assign(context, { app: this, lruGatewayResolvers, errors: null })
+    context = assignLifeCycleHooksToContext(context, fastifyGraphQl[kHooks])
     const reply = context.reply
 
     // Trigger preParsing hook

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -45,15 +45,15 @@ Hooks.prototype.add = function (hook, fn) {
   this[hook].push(fn)
 }
 
-function assignApplicationLifecycleHooksToContext (hooks, context) {
+function assignApplicationLifecycleHooksToContext (context, hooks) {
   const contextHooks = {
     onGatewayReplaceSchema: null
   }
   if (hooks.onGatewayReplaceSchema.length > 0) contextHooks.onGatewayReplaceSchema = hooks.onGatewayReplaceSchema.slice()
-  return Object.assign(contextHooks, context)
+  return Object.assign(context, contextHooks)
 }
 
-function assignLifeCycleHooksToContext (hooks, context) {
+function assignLifeCycleHooksToContext (context, hooks) {
   const contextHooks = {
     preParsing: null,
     preValidation: null,
@@ -76,7 +76,7 @@ function assignLifeCycleHooksToContext (hooks, context) {
   if (hooks.preGatewaySubscriptionExecution.length > 0) contextHooks.preGatewaySubscriptionExecution = hooks.preGatewaySubscriptionExecution.slice()
   if (hooks.onSubscriptionResolution.length > 0) contextHooks.onSubscriptionResolution = hooks.onSubscriptionResolution.slice()
   if (hooks.onSubscriptionEnd.length > 0) contextHooks.onSubscriptionEnd = hooks.onSubscriptionEnd.slice()
-  return Object.assign(contextHooks, context)
+  return Object.assign(context, contextHooks)
 }
 
 async function hooksRunner (functions, runner, request) {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -178,7 +178,7 @@ module.exports = async function (app, opts) {
     }
 
     // Handle the query, throwing an error if required
-    return reply.graphql(query, { pubsub: subscriber, ...context, __currentQuery: query }, variables, operationName)
+    return reply.graphql(query, Object.assign(context, { pubsub: subscriber, __currentQuery: query }), variables, operationName)
   }
 
   function executeRegularQuery (body, request, reply) {

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -25,9 +25,9 @@ function createConnectionHandler ({ subscriber, fastify, onConnect, onDisconnect
     }
 
     if (context.app.graphql && context.app.graphql[kHooks]) {
-      context = assignLifeCycleHooksToContext(context.app.graphql[kHooks], context)
+      context = assignLifeCycleHooksToContext(context, context.app.graphql[kHooks])
     } else {
-      context = assignLifeCycleHooksToContext(new Hooks(), context)
+      context = assignLifeCycleHooksToContext(context, new Hooks())
     }
 
     let resolveContext


### PR DESCRIPTION
Use provided `context` as a target in merging to keep the object prototype.
Resolves: #514 