### PR TITLE
Validate the disable instrospection custom rule

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,19 @@
+# FAQ
+
+This page answers common asked questions about Mercurius.
+
+## Disable Graphql instrospection
+To disable Graphql instrospection you can use `NoSchemaIntrospectionCustomRule` from graphql, we have an example on "example/disable-instrospection.js", using this approach:
+
+```js
+import { NoSchemaIntrospectionCustomRule } from 'graphql';
+
+app.register(mercurius, {
+  context: buildContext,
+  gateway: {
+    services: [....],
+    pollingInterval: 30000,
+  },
+  validationRules: process.env.NODE_ENV === 'production' && [NoSchemaIntrospectionCustomRule],
+});
+```

--- a/examples/disable-introspection.js
+++ b/examples/disable-introspection.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const Fastify = require('fastify')
+const mercurius = require('..')
+const graphql = require('graphql')
+
+const app = Fastify()
+
+const schema = `
+  type Query {
+    add(x: Int, y: Int): Int
+  }
+`
+
+const resolvers = {
+  Query: {
+    add: async (_, obj) => {
+      const { x, y } = obj
+      return x + y
+    }
+  }
+}
+
+app.register(mercurius, {
+  schema,
+  resolvers,
+  graphiql: true,
+  validationRules: [graphql.NoSchemaIntrospectionCustomRule]
+})
+
+app.get('/', async function (req, reply) {
+  const query = '{ add(x: 2, y: 2) }'
+  return reply.graphql(query)
+})
+
+app.listen(3000)

--- a/test/disable-instrospection.js
+++ b/test/disable-instrospection.js
@@ -1,0 +1,67 @@
+'use strict'
+
+const { test } = require('tap')
+const Fastify = require('fastify')
+const mercurius = require('..')
+const graphql = require('graphql')
+
+const schema = `
+  type Query {
+    add(x: Int, y: Int): Int
+  }
+`
+
+const resolvers = {
+  Query: {
+    add: async (_, obj) => {
+      const { x, y } = obj
+      return x + y
+    }
+  }
+}
+
+test('should disallow instrospection with "__schema" when NoSchemaIntrospectionCustomRule are applied to validationRules', async (t) => {
+  const app = Fastify()
+
+  const query = '{ __schema { queryType { name } } }'
+
+  app.register(mercurius, {
+    schema,
+    resolvers,
+    graphiql: true,
+    validationRules: [graphql.NoSchemaIntrospectionCustomRule]
+  })
+
+  // needed so that graphql is defined
+  await app.ready()
+
+  try {
+    await app.graphql(query)
+  } catch (e) {
+    t.equal(e.errors.length > 0, true)
+    t.equal(e.errors[0].message, 'GraphQL introspection has been disabled, but the requested query contained the field "__schema".')
+  }
+})
+
+test('should disallow instrospection with "__type" when NoSchemaIntrospectionCustomRule are applied to validationRules', async (t) => {
+  const app = Fastify()
+
+  const query = '{ __type(name: "Query"){ name } }'
+
+  app.register(mercurius, {
+    schema,
+    resolvers,
+    graphiql: true,
+    validationRules: [graphql.NoSchemaIntrospectionCustomRule]
+  })
+
+  // needed so that graphql is defined
+  await app.ready()
+
+  try {
+    await app.graphql(query)
+  } catch (e) {
+    t.equal(e.errors.length > 0, true)
+    t.equal(e.errors[0].message, 'GraphQL introspection has been disabled, but the requested query contained the field "__type".')
+  }
+})


### PR DESCRIPTION
I have created an example of how to disable instrospection using the rule from graphql "NoSchemaIntrospectionCustomRule".
And a isolated test that validate the response errors from graphql with the instrospection rule.

#521