### PR TITLE
Add GraphiQL request headers tab

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -32,7 +32,11 @@ function render () {
   }
 
   ReactDOM.render(
-    React.createElement(GraphiQL, { fetcher }),
+    React.createElement(GraphiQL, {
+      fetcher,
+      headerEditorEnabled: true,
+      shouldPersistHeaders: true
+    }),
     document.getElementById('main')
   )
 }


### PR DESCRIPTION
I was missing the request headers tab so I enabled it again - I think this is in favour of everyone.