### PR TITLE
Fix duplicate custom directives in the gateway schema

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -173,6 +173,10 @@ const errors = {
     'MER_ERR_GQL_GATEWAY_MISSING_KEY_DIRECTIVE',
     'Missing @key directive in %s type'
   ),
+  MER_ERR_GQL_GATEWAY_DUPLICATE_DIRECTIVE: createError(
+    'MER_ERR_GQL_GATEWAY_DUPLICATE_DIRECTIVE',
+    'Directive with a different definition but the same name "%s" already exists in the gateway schema'
+  ),
   /**
    * Persisted query errors
    */

--- a/lib/federation.js
+++ b/lib/federation.js
@@ -30,13 +30,16 @@ const {
   Kind,
   extendSchema,
   parse,
+  print,
   isTypeDefinitionNode,
   isTypeExtensionNode,
-  isObjectType
+  isObjectType,
+  isSpecifiedDirective,
+  GraphQLDirective
 } = require('graphql')
 const { validateSDL } = require('graphql/validation/validate')
 const compositionRules = require('./federation/compositionRules')
-const { MER_ERR_GQL_INVALID_SCHEMA, MER_ERR_GQL_GATEWAY_INVALID_SCHEMA } = require('./errors')
+const { MER_ERR_GQL_INVALID_SCHEMA, MER_ERR_GQL_GATEWAY_INVALID_SCHEMA, MER_ERR_GQL_GATEWAY_DUPLICATE_DIRECTIVE } = require('./errors')
 const { hasExtensionDirective } = require('./util')
 
 const BASE_FEDERATION_TYPES = `
@@ -224,6 +227,37 @@ function addServiceResolver (schema, originalSchemaSDL) {
   return schema
 }
 
+function buildGatewaySchemaDirectives (schema) {
+  // Remove service federation directives which should not be present in the gateway
+  const federationDirectiveNames = parse(BASE_FEDERATION_TYPES).definitions
+    .filter(definition => definition.kind === 'DirectiveDefinition')
+    .map(definition => definition.name.value)
+  const directives = schema.getDirectives()
+    .filter(directive => !federationDirectiveNames.includes(directive.name))
+
+  // De-duplicate custom directives
+  const gatewayDirectives = []
+  for (const directive of directives) {
+    if (!isSpecifiedDirective(directive)) {
+      const directiveToCompareAgainst = gatewayDirectives
+        .find(gatewayDirective => gatewayDirective.name === directive.name)
+      if (directiveToCompareAgainst instanceof GraphQLDirective) {
+        const directiveSDL = print(directive.astNode)
+        const duplicatedDirectiveSDL = print(directiveToCompareAgainst.astNode)
+        if (directiveSDL !== duplicatedDirectiveSDL) {
+          throw new MER_ERR_GQL_GATEWAY_DUPLICATE_DIRECTIVE(directive.name)
+        }
+      } else {
+        gatewayDirectives.push(directive)
+      }
+    } else {
+      gatewayDirectives.push(directive)
+    }
+  }
+
+  return gatewayDirectives
+}
+
 function buildFederationSchema (schema, isGateway) {
   let federationSchema = new GraphQLSchema({
     query: undefined
@@ -286,11 +320,13 @@ function buildFederationSchema (schema, isGateway) {
     federationSchema = addServiceResolver(federationSchema, schema)
   }
 
+  const federationSchemaConfig = federationSchema.toConfig()
   return new GraphQLSchema({
-    ...federationSchema.toConfig(),
+    ...federationSchemaConfig,
     query: federationSchema.getType('Query'),
     mutation: federationSchema.getType('Mutation'),
-    subscription: federationSchema.getType('Subscription')
+    subscription: federationSchema.getType('Subscription'),
+    directives: isGateway ? buildGatewaySchemaDirectives(federationSchema) : federationSchemaConfig.directives
   })
 }
 

--- a/test/gateway/custom-directives.js
+++ b/test/gateway/custom-directives.js
@@ -1,0 +1,211 @@
+'use strict'
+
+const { test } = require('tap')
+const Fastify = require('fastify')
+const GQL = require('../..')
+
+async function createTestService (t, schema, resolvers = {}) {
+  const service = Fastify()
+  service.register(GQL, {
+    schema,
+    resolvers,
+    federationMetadata: true
+  })
+  await service.listen(0)
+  return [service, service.server.address().port]
+}
+
+const users = {
+  u1: {
+    id: 'u1',
+    name: 'John'
+  },
+  u2: {
+    id: 'u2',
+    name: 'Jane'
+  }
+}
+
+const posts = {
+  p1: {
+    pid: 'p1',
+    title: 'Post 1',
+    content: 'Content 1',
+    authorId: 'u1'
+  },
+  p2: {
+    pid: 'p2',
+    title: 'Post 2',
+    content: 'Content 2',
+    authorId: 'u2'
+  },
+  p3: {
+    pid: 'p3',
+    title: 'Post 3',
+    content: 'Content 3',
+    authorId: 'u1'
+  },
+  p4: {
+    pid: 'p4',
+    title: 'Post 4',
+    content: 'Content 4',
+    authorId: 'u1'
+  }
+}
+
+const query = `
+  query {
+    me {
+      id
+      name
+      topPosts(count: 2) {
+        pid
+        author {
+          id
+        }
+      }
+    }
+    topPosts(count: 2) {
+      pid
+    }
+  }
+`
+
+async function createTestGatewayServer (t, opts = {}) {
+  // User service
+  const userServiceSchema = `
+  directive @custom on OBJECT | FIELD_DEFINITION
+
+  type Query @extends {
+    me: User @custom
+  }
+
+  type User @key(fields: "id") {
+    id: ID!
+    name: String! @custom
+  }`
+  const userServiceResolvers = {
+    Query: {
+      me: (root, args, context, info) => {
+        return users.u1
+      }
+    },
+    User: {
+      __resolveReference: (user, args, context, info) => {
+        return users[user.id]
+      }
+    }
+  }
+  const [userService, userServicePort] = await createTestService(t, userServiceSchema, userServiceResolvers)
+
+  // Post service
+  const postServiceSchema = `
+  directive @custom on OBJECT | FIELD_DEFINITION
+
+  type Post @key(fields: "pid") {
+    pid: ID! @custom
+    author: User
+  }
+
+  extend type Query {
+    topPosts(count: Int): [Post]
+  }
+
+  type User @key(fields: "id") @extends {
+    id: ID! @external
+    topPosts(count: Int!): [Post]
+  }`
+  const postServiceResolvers = {
+    Post: {
+      __resolveReference: (post, args, context, info) => {
+        return posts[post.pid]
+      },
+      author: (post, args, context, info) => {
+        return {
+          __typename: 'User',
+          id: post.authorId
+        }
+      }
+    },
+    User: {
+      topPosts: (user, { count }, context, info) => {
+        return Object.values(posts).filter(p => p.authorId === user.id).slice(0, count)
+      }
+    },
+    Query: {
+      topPosts: (root, { count = 2 }) => Object.values(posts).slice(0, count)
+    }
+  }
+  const [postService, postServicePort] = await createTestService(t, postServiceSchema, postServiceResolvers)
+
+  const gateway = Fastify()
+  t.teardown(async () => {
+    await gateway.close()
+    await userService.close()
+    await postService.close()
+  })
+  gateway.register(GQL, {
+    ...opts,
+    gateway: {
+      services: [{
+        name: 'user',
+        url: `http://localhost:${userServicePort}/graphql`
+      }, {
+        name: 'post',
+        url: `http://localhost:${postServicePort}/graphql`
+      }]
+    }
+  })
+  return gateway
+}
+
+// ---------------------------
+// Gateway - custom directive
+// ---------------------------
+test('gateway - should handle custom directives', async (t) => {
+  t.plan(2)
+  const app = await createTestGatewayServer(t)
+
+  const directiveNames = app.graphql.schema.getDirectives().map(directive => directive.name).filter(name => name === 'custom')
+
+  // Should contain a single representation of the custom directive
+  t.equal(directiveNames, ['custom'])
+
+  const res = await app.inject({
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    url: '/graphql',
+    body: JSON.stringify({ query })
+  })
+
+  t.same(JSON.parse(res.body), {
+    data: {
+      me: {
+        id: 'u1',
+        name: 'John',
+        topPosts: [
+          {
+            pid: 'p1',
+            author: {
+              id: 'u1'
+            }
+          },
+          {
+            pid: 'p3',
+            author: {
+              id: 'u1'
+            }
+          }
+        ]
+      },
+      topPosts: [
+        {
+          pid: 'p1'
+        },
+        {
+          pid: 'p2'
+        }
+      ]
+    }
+  })
+})


### PR DESCRIPTION
This fixes the issue report here: https://github.com/mercurius-js/mercurius/issues/343#issuecomment-900593479

I found another issue with the GraphQL server not closing properly if the federated schema throws for any reason. I'll resolve this in a follow up PR as the change is out of scope for this PR :)