### PR TITLE
move graphql into peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ Features:
 ## Install
 
 ```bash
-npm i fastify mercurius
+npm i fastify mercurius graphql
+# or
+yarn add fastify mercurius graphql
 ```
 
 The previous name of this module was [fastify-gql](http://npm.im/fastify-gql) (< 6.0.0).

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "url": "https://github.com/mercurius-js/mercurius/issues"
   },
   "homepage": "https://mercurius.dev",
+  "peerDependencies": {
+    "graphql": "^15.5.1"
+  },
   "devDependencies": {
     "@graphql-tools/merge": "^8.0.0",
     "@graphql-tools/schema": "^8.0.0",
@@ -37,6 +40,7 @@
     "concurrently": "^6.2.0",
     "docsify-cli": "^4.4.3",
     "fastify": "^3.18.1",
+    "graphql": "^15.5.1",
     "graphql-middleware": "^6.0.10",
     "graphql-shield": "^7.5.0",
     "graphql-tools": "^8.0.0",
@@ -58,7 +62,6 @@
     "fastify-plugin": "^3.0.0",
     "fastify-static": "^4.2.2",
     "fastify-websocket": "^4.0.0",
-    "graphql": "^15.5.1",
     "graphql-jit": "^0.5.1",
     "mqemitter": "^4.4.1",
     "p-map": "^4.0.0",


### PR DESCRIPTION
When user installs graphql into their own package.json alongside `mercurius`, they get:
```
Ensure that there is only one instance of "graphql" in the node_modules
directory. If different versions of "graphql" are the dependencies of other
relied on modules, use "resolutions" to ensure only one version is installed.

https://yarnpkg.com/en/docs/selective-version-resolutions

Duplicate "graphql" modules cannot be used at the same time since different
versions may have different capabilities and behavior. The data from one
version used in the function from another could produce confusing and
spurious results.
```

This is a common problem with graphql package. It was previously discussed here for example: https://github.com/MichalLytek/type-graphql/issues/144 

Beware-this is a breaking change. Consumers of mercurius will need to go in and add graphql as direct dependency when this gets released. 