### PR TITLE
docs(typescript): fix mercurius-codegen example

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -61,7 +61,7 @@ app.register(mercurius, {
   context: buildContext
 })
 
-mercuriusCodegen(mercurius, {
+mercuriusCodegen(app, {
   // Commonly relative to your root package.json
   targetPath: './src/graphql/generated.ts'
 }).catch(console.error)


### PR DESCRIPTION
The current example in the docs passes the `mercurius` instance to `mercuriusCodegen` instead of the Fastify instance. This PR fixes the example.