### PR TITLE
fix(typescript): Fixed error handling types.

### DIFF
--- a/docs/federation.md
+++ b/docs/federation.md
@@ -374,14 +374,14 @@ server.register(mercurius, {
         name: 'company',
         url: 'http://localhost:3001/graphql'
       }
-    ]
+    ],
+    errorHandler: (error, service) => {
+      if (service.mandatory) {
+        server.log.error(error)
+      }
+    },
   },
-  pollingInterval: 2000,
-  errorHandler: (error, service) => {
-    if (service.mandatory) {
-      logger.error(error)
-    }
-  }
+  pollingInterval: 2000
 })
 
 server.listen(3002)

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,8 +10,6 @@ import {
   GraphQLSchema,
   Source,
   GraphQLResolveInfo,
-  GraphQLIsTypeOfFn,
-  GraphQLTypeResolver,
   GraphQLScalarType,
   ValidationRule,
 } from "graphql";
@@ -31,6 +29,10 @@ export interface MercuriusContext {
    * __Caution__: Only available if `subscriptions` are enabled
    */
   pubsub: PubSub;
+}
+
+export interface MercuriusError<TError extends Error = Error> extends FastifyError {
+  errors?: TError[]
 }
 
 export interface Loader<
@@ -459,12 +461,12 @@ export interface MercuriusCommonOptions {
   defineMutation?: boolean;
   /**
    * Change the default error handler (Default: true).
-   * If a custom error handler is defined, it should return the standardized response format according to [GraphQL spec](https://graphql.org/learn/serving-over-http/#response).
+   * If a custom error handler is defined, it should send the standardized response format according to [GraphQL spec](https://graphql.org/learn/serving-over-http/#response) using `reply.send`.
    * @default true
    */
   errorHandler?:
     | boolean
-    | ((error: FastifyError, request: FastifyRequest, reply: FastifyReply) => ExecutionResult);
+    | ((error: MercuriusError, request: FastifyRequest, reply: FastifyReply) => void | Promise<void>);
   /**
    * Change the default error formatter.
    */

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -83,6 +83,34 @@ app.register(mercurius, {
 })
 
 app.register(mercurius, {
+  schema: schema,
+  resolvers,
+  loaders: {},
+  ide: false,
+  jit: 1,
+  routes: true,
+  prefix: '/prefix',
+  defineMutation: false,
+  errorHandler: async function (err, request, reply) {
+    reply.send({ errors: err.errors })
+  },
+  errorFormatter: (result, context) => {
+    context.reply
+    result.data
+    result.errors?.forEach((e) => e.message)
+    return { statusCode: 200, response: result }
+  },
+  queryDepth: 8,
+  cache: true,
+  context: (request) => {
+    return {
+      request
+    }
+  },
+  schemaTransforms: (schema) => schema
+})
+
+app.register(mercurius, {
   schema,
   errorFormatter: mercurius.defaultErrorFormatter,
   schemaTransforms: [(schema) => schema],


### PR DESCRIPTION
Hello!
This PR fixes wrong TypeScript specification for the `errorHandler` option.
By digging in the code I noticed that handler is used in fastify's `setErrorHandler` which does not allow a return type.
The response must be sent to the client using `reply.send`. The only difference with fastify is that the error type can optionally (and most of the times will) include a `errors` array, so I've created a specific exported type.

I've also fixed the example for the federated use-case.