### PR TITLE
[bugfix]: graphiql broken due to invalid websocket prototcol "wss::"

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -19,10 +19,10 @@ const importer = {
 function render () {
   const host = window.location.host
 
-  const websocketProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws'
+  const websocketProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
 
   const url = `${window.location.protocol}//${host}${window.GRAPHQL_ENDPOINT}`
-  const subscriptionUrl = `${websocketProtocol}://${host}${window.GRAPHQL_ENDPOINT}`
+  const subscriptionUrl = `${websocketProtocol}//${host}${window.GRAPHQL_ENDPOINT}`
 
   const fetcher = GraphiQL.createFetcher({
     url,


### PR DESCRIPTION
Issue:
A stray colon causing problems when using graphiql over https.

Impact:
Graphiql fails to start, with the following error in the console:
```DOMException: Failed to construct 'WebSocket': The URL 'wss:://[redacted]/graphql' is invalid.```

Solution:
Remove the extra colon