### PR TITLE
match graphiql resource paths

### DIFF
--- a/static/graphiql.html
+++ b/static/graphiql.html
@@ -17,7 +17,7 @@
 </head>
 <body>
   <div id="main"></div>
-  <script src="./graphiql/config.js"></script>
-  <script src="./graphiql/main.js"></script>
+  <script src="/graphiql/config.js"></script>
+  <script src="/graphiql/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
As defined in `routes.js`:

```js
app.get('/graphiql/main.js', (req, reply) => {
  // ...
})

app.get('/graphiql/config.js', (req, reply) => {
  // ...
})
```

and so when we reference these resources in the html, it should match the paths so they start from root, not the current path.