### PR TITLE
Add info object to loaders

### DIFF
--- a/docs/loaders.md
+++ b/docs/loaders.md
@@ -9,10 +9,11 @@ also cache the results, so that other parts of the GraphQL do not have
 to fetch the same data.
 
 Each loader function has the signature `loader(queries, context)`.
-`queries` is an array of objects defined as `{ obj, params }` where
-`obj` is the current object and `params` are the GraphQL params (those
-are the first two parameters of a normal resolver). The `context` is the
-GraphQL context, and it includes a `reply` object.
+`queries` is an array of objects defined as `{ obj, params, info }` where
+`obj` is the current object, `params` are the GraphQL params (those
+are the first two parameters of a normal resolver) and `info` contains
+additional information about the query and execution. The `context` is 
+the GraphQL context, and it includes a `reply` object.
 
 Example:
 

--- a/docs/loaders.md
+++ b/docs/loaders.md
@@ -12,8 +12,9 @@ Each loader function has the signature `loader(queries, context)`.
 `queries` is an array of objects defined as `{ obj, params, info }` where
 `obj` is the current object, `params` are the GraphQL params (those
 are the first two parameters of a normal resolver) and `info` contains
-additional information about the query and execution. The `context` is 
-the GraphQL context, and it includes a `reply` object.
+additional information about the query and execution. `info` object is
+only available in the loader if the cache is set to `false`. The `context`
+is the GraphQL context, and it includes a `reply` object.
 
 Example:
 

--- a/index.js
+++ b/index.js
@@ -368,12 +368,12 @@ const plugin = fp(async function (app, opts) {
 
     function defineLoader (name) {
       // async needed because of throw
-      return async function (obj, params, { reply }) {
+      return async function (obj, params, { reply }, info) {
         if (!reply) {
           throw new MER_ERR_INVALID_OPTS('loaders only work via reply.graphql()')
         }
 
-        return reply[kLoaders][name]({ obj, params })
+        return reply[kLoaders][name]({ obj, params, info })
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -373,7 +373,9 @@ const plugin = fp(async function (app, opts) {
           throw new MER_ERR_INVALID_OPTS('loaders only work via reply.graphql()')
         }
 
-        return reply[kLoaders][name]({ obj, params, info })
+        const query = opts.cache === false ? { obj, params, info } : { obj, params }
+
+        return reply[kLoaders][name](query)
       }
     }
 

--- a/test/federation.js
+++ b/test/federation.js
@@ -919,8 +919,7 @@ test('federation supports loader for __resolveReference function', async (t) => 
   const loaders = {
     User: {
       async __resolveReference (queries, { reply }) {
-        const queriesObj = queries.map(({ obj, params }) => ({ obj, params }))
-        t.same(queriesObj, [{
+        t.same(queries, [{
           obj: {
             __typename: 'User',
             id: '1'

--- a/test/federation.js
+++ b/test/federation.js
@@ -919,7 +919,8 @@ test('federation supports loader for __resolveReference function', async (t) => 
   const loaders = {
     User: {
       async __resolveReference (queries, { reply }) {
-        t.same(queries, [{
+        const queriesObj = queries.map(({ obj, params }) => ({ obj, params }))
+        t.same(queriesObj, [{
           obj: {
             __typename: 'User',
             id: '1'

--- a/test/loaders.js
+++ b/test/loaders.js
@@ -783,58 +783,58 @@ test('support info in loader', async (t) => {
 
   t.equal(res.statusCode, 200)
   t.strictSame(JSON.parse(res.body), {
-    "data": {
-      "dogs": [
+    data: {
+      dogs: [
         {
-          "dogName": "Max",
-          "age": 10,
-          "owner": {
-            "nickName": "Jennifer",
-            "age": 25
+          dogName: 'Max',
+          age: 10,
+          owner: {
+            nickName: 'Jennifer',
+            age: 25
           }
         },
         {
-          "dogName": "Charlie",
-          "age": 13,
-          "owner": {
-            "nickName": "Sarah",
-            "age": 35
+          dogName: 'Charlie',
+          age: 13,
+          owner: {
+            nickName: 'Sarah',
+            age: 35
           }
         },
         {
-          "dogName": "Buddy",
-          "age": 15,
-          "owner": {
-            "nickName": "Tracy",
-            "age": 45
+          dogName: 'Buddy',
+          age: 15,
+          owner: {
+            nickName: 'Tracy',
+            age: 45
           }
         },
         {
-          "dogName": "Max",
-          "age": 17,
-          "owner": {
-            "nickName": "Jennifer",
-            "age": 25
+          dogName: 'Max',
+          age: 17,
+          owner: {
+            nickName: 'Jennifer',
+            age: 25
           }
         }
       ],
-      "cats": [
+      cats: [
         {
-          "catName": "Charlie",
-          "owner": {
-            "age": 35
+          catName: 'Charlie',
+          owner: {
+            age: 35
           }
         },
         {
-          "catName": "Max",
-          "owner": {
-            "age": 25
+          catName: 'Max',
+          owner: {
+            age: 25
           }
         },
         {
-          "catName": "Buddy",
-          "owner": {
-            "age": 45
+          catName: 'Buddy',
+          owner: {
+            age: 45
           }
         }
       ]

--- a/test/loaders.js
+++ b/test/loaders.js
@@ -71,7 +71,8 @@ test('loaders create batching resolvers', async (t) => {
     Dog: {
       async owner (queries, { reply }) {
         // note that the second entry for max is cached
-        t.same(queries, [{
+        const queriesObj = queries.map(({ obj, params }) => ({ obj, params }))
+        t.same(queriesObj, [{
           obj: {
             name: 'Max'
           },
@@ -84,6 +85,11 @@ test('loaders create batching resolvers', async (t) => {
         }, {
           obj: {
             name: 'Buddy'
+          },
+          params: {}
+        }, {
+          obj: {
+            name: 'Max'
           },
           params: {}
         }])
@@ -142,7 +148,8 @@ test('disable cache for each loader', async (t) => {
       owner: {
         async loader (queries, { reply }) {
           // note that the second entry for max is NOT cached
-          t.same(queries, [{
+          const queriesObj = queries.map(({ obj, params }) => ({ obj, params }))
+          t.same(queriesObj, [{
             obj: {
               name: 'Max'
             },
@@ -481,7 +488,8 @@ test('loaders support custom context', async (t) => {
       async owner (queries, { reply, test }) {
         t.equal(test, 'custom')
         // note that the second entry for max is cached
-        t.same(queries, [{
+        const queriesObj = queries.map(({ obj, params }) => ({ obj, params }))
+        t.same(queriesObj, [{
           obj: {
             name: 'Max'
           },
@@ -494,6 +502,11 @@ test('loaders support custom context', async (t) => {
         }, {
           obj: {
             name: 'Buddy'
+          },
+          params: {}
+        }, {
+          obj: {
+            name: 'Max'
           },
           params: {}
         }])

--- a/test/loaders.js
+++ b/test/loaders.js
@@ -623,3 +623,221 @@ test('subscriptions properly execute loaders', t => {
     })
   })
 })
+
+test('support info in loader', async (t) => {
+  const app = Fastify()
+
+  const dogs = [{
+    dogName: 'Max',
+    age: 10
+  }, {
+    dogName: 'Charlie',
+    age: 13
+  }, {
+    dogName: 'Buddy',
+    age: 15
+  }, {
+    dogName: 'Max',
+    age: 17
+  }]
+
+  const cats = [{
+    catName: 'Charlie',
+    age: 10
+  }, {
+    catName: 'Max',
+    age: 13
+  }, {
+    catName: 'Buddy',
+    age: 15
+  }]
+
+  const owners = {
+    Max: {
+      nickName: 'Jennifer',
+      age: 25
+    },
+    Charlie: {
+      nickName: 'Sarah',
+      age: 35
+    },
+    Buddy: {
+      nickName: 'Tracy',
+      age: 45
+    }
+  }
+
+  const schema = `
+    type Human {
+      nickName: String!
+      age: Int!
+    }
+
+    type Dog {
+      dogName: String!
+      age: Int!
+      owner: Human
+    }
+
+    type Cat {
+      catName: String!
+      age: Int!
+      owner: Human
+    }
+
+    type Query {
+      dogs: [Dog]
+      cats: [Cat]
+    }
+  `
+
+  const query = `{
+    dogs {
+      dogName
+      age
+      owner {
+        nickName
+        age
+      }
+    }
+    cats {
+      catName
+      owner {
+        age
+      }
+    }
+  }`
+  const resolvers = {
+    Query: {
+      dogs: (_, params, context) => {
+        return dogs
+      },
+      cats: (_, params, context) => {
+        return cats
+      }
+    }
+  }
+
+  const loaders = {
+    Dog: {
+      async owner (queries, context) {
+        t.equal(context.app, app)
+        return queries.map(({ obj, info }) => {
+          // verify info properties
+          t.equal(info.operation.operation, 'query')
+
+          const resolverOutputParams = info.operation.selectionSet.selections[0].selectionSet.selections
+          t.equal(resolverOutputParams.length, 3)
+          t.equal(resolverOutputParams[0].name.value, 'dogName')
+          t.equal(resolverOutputParams[1].name.value, 'age')
+          t.equal(resolverOutputParams[2].name.value, 'owner')
+
+          const loaderOutputParams = resolverOutputParams[2].selectionSet.selections
+
+          t.equal(loaderOutputParams.length, 2)
+          t.equal(loaderOutputParams[0].name.value, 'nickName')
+          t.equal(loaderOutputParams[1].name.value, 'age')
+
+          return owners[obj.dogName]
+        })
+      }
+    },
+    Cat: {
+      async owner (queries, context) {
+        t.equal(context.app, app)
+        return queries.map(({ obj, info }) => {
+          // verify info properties
+          t.equal(info.operation.operation, 'query')
+
+          const resolverOutputParams = info.operation.selectionSet.selections[1].selectionSet.selections
+          t.equal(resolverOutputParams.length, 2)
+          t.equal(resolverOutputParams[0].name.value, 'catName')
+          t.equal(resolverOutputParams[1].name.value, 'owner')
+
+          const loaderOutputParams = resolverOutputParams[1].selectionSet.selections
+
+          t.equal(loaderOutputParams.length, 1)
+          t.equal(loaderOutputParams[0].name.value, 'age')
+
+          return owners[obj.catName]
+        })
+      }
+    }
+  }
+
+  app.register(GQL, {
+    schema,
+    resolvers,
+    loaders
+  })
+
+  await app.ready()
+
+  const res = await app.inject({
+    method: 'POST',
+    url: '/graphql',
+    body: {
+      query
+    }
+  })
+
+  t.equal(res.statusCode, 200)
+  t.strictSame(JSON.parse(res.body), {
+    "data": {
+      "dogs": [
+        {
+          "dogName": "Max",
+          "age": 10,
+          "owner": {
+            "nickName": "Jennifer",
+            "age": 25
+          }
+        },
+        {
+          "dogName": "Charlie",
+          "age": 13,
+          "owner": {
+            "nickName": "Sarah",
+            "age": 35
+          }
+        },
+        {
+          "dogName": "Buddy",
+          "age": 15,
+          "owner": {
+            "nickName": "Tracy",
+            "age": 45
+          }
+        },
+        {
+          "dogName": "Max",
+          "age": 17,
+          "owner": {
+            "nickName": "Jennifer",
+            "age": 25
+          }
+        }
+      ],
+      "cats": [
+        {
+          "catName": "Charlie",
+          "owner": {
+            "age": 35
+          }
+        },
+        {
+          "catName": "Max",
+          "owner": {
+            "age": 25
+          }
+        },
+        {
+          "catName": "Buddy",
+          "owner": {
+            "age": 45
+          }
+        }
+      ]
+    }
+  })
+})


### PR DESCRIPTION
This PR adds support for the `info` object being passed to the loaders.

Each loader function has the signature loader(queries, context).  `queries` is an array of objects and is now defined as `{ obj, params, info }`

Closes #627 