### PR TITLE
[bugfix]: "Cannot read property 'create' of undefined" with encapsulated app where parent object has loaders defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -258,7 +258,7 @@ const plugin = fp(async function (app, opts) {
 
     context = Object.assign(context, { reply: this, app })
     if (app[kFactory]) {
-      this[kLoaders] = factory.create(context)
+      this[kLoaders] = app[kFactory].create(context)
     }
 
     return app.graphql(source, context, variables, operationName)

--- a/tap-snapshots/test/reply-decorator.js.test.cjs
+++ b/tap-snapshots/test/reply-decorator.js.test.cjs
@@ -8,3 +8,7 @@
 exports['test/reply-decorator.js TAP reply decorator set status code to 400 with bad query > must match snapshot 1'] = `
 {"errors":[{"message":"Syntax Error: Expected Name, found <EOF>.","locations":[{"line":1,"column":18}]}]}
 `
+
+exports['test/reply-decorator.js TAP reply decorator supports encapsulation when loaders are defined in parent object > must match snapshot 1'] = `
+{"data":{"multiply":25}}
+`


### PR DESCRIPTION
In an effort to create a new graphql endpoint, I was encountering the following error when registering the following plugin code:
NOTE: the parent app object has loaders defined in a separate module. 

```javascript

'use strict'

const fp = require('fastify-plugin')
const GQL = require('mercurius')

const schema = `
  type Query {
    msg: String
  }
`

const resolvers = {
  Query: {
    msg
  }
}

async function msg(_, args, context) {
  return "hello world!"
}


async function plugin(server) {


  server.register(async (app) => {
    app.register(GQL, {
      schema,
      defineMutation: true,
      resolvers,
      path: '/auth'
    })
  })
}

module.exports = fp(plugin, {
  name: 'auth',
  dependencies: ['db', 'redis']
})
```

Upon issuing the following request:

```bash
curl 'localhost:5000/auth' -X POST -H 'Content-Type: application/json' --data-raw '{"query":"query { msg }","variables":null}' | jq
```

I am receiving the following response:

```json
{
  "data": null,
  "errors": [
    {
      "message": "Cannot read property 'create' of undefined"
    }
  ]
}
```


With this bug fix, this problem is now resolved. the factory object is otherwise not in scope when registering the new route this way.

I absolutely need multiple graphql routes for the problem I am trying to solve and this fix has resolved my issue. 