### PR TITLE
Fix: Graphiql not working without sw

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -39,25 +39,28 @@ function render () {
   )
 }
 
+function importDependencies () {
+  const link = document.createElement('link')
+  link.href = 'https://unpkg.com/graphiql@1.4.2/graphiql.css'
+  link.type = 'text/css'
+  link.rel = 'stylesheet'
+  link.media = 'screen,print'
+  document.getElementsByTagName('head')[0].appendChild(link)
+
+  return importer.urls([
+    'https://unpkg.com/react@16.8.0/umd/react.production.min.js',
+    'https://unpkg.com/react-dom@16.8.0/umd/react-dom.production.min.js',
+    'https://unpkg.com/graphiql@1.4.2/graphiql.min.js',
+    'https://unpkg.com/subscriptions-transport-ws@0.9.19/browser/client.js'
+  ])
+}
+
 if ('serviceWorker' in navigator) {
   navigator
     .serviceWorker
     .register('./graphiql/sw.js')
-    .then(function () {
-      const link = document.createElement('link')
-      link.href = 'https://unpkg.com/graphiql@1.4.2/graphiql.css'
-      link.type = 'text/css'
-      link.rel = 'stylesheet'
-      link.media = 'screen,print'
-      document.getElementsByTagName('head')[0].appendChild(link)
-
-      return importer.urls([
-        'https://unpkg.com/react@16.8.0/umd/react.production.min.js',
-        'https://unpkg.com/react-dom@16.8.0/umd/react-dom.production.min.js',
-        'https://unpkg.com/graphiql@1.4.2/graphiql.min.js',
-        'https://unpkg.com/subscriptions-transport-ws@0.9.19/browser/client.js'
-      ])
-    }).then(render)
+    .then(importDependencies).then(render)
 } else {
-  render()
+  importDependencies()
+    .then(render)
 }


### PR DESCRIPTION
This PR fixes an issue with graphiql when we try to load it without service workers.

Closes #625 