### PR TITLE
Fix incorrect message type for GQL_STOP when using graphql-transport-ws

### DIFF
--- a/lib/subscription-protocol.js
+++ b/lib/subscription-protocol.js
@@ -1,11 +1,14 @@
 'use strict'
 
 const GRAPHQL_WS = 'graphql-ws'
+const GRAPHQL_TRANSPORT_WS = 'graphql-transport-ws'
+
 module.exports.GRAPHQL_WS = GRAPHQL_WS
+module.exports.GRAPHQL_TRANSPORT_WS = GRAPHQL_TRANSPORT_WS
 
 module.exports.getProtocolByName = function (name) {
   switch (true) {
-    case (name.indexOf('graphql-transport-ws') !== -1):
+    case (name.indexOf(GRAPHQL_TRANSPORT_WS) !== -1):
       return {
         GQL_CONNECTION_INIT: 'connection_init', // Client -> Server
         GQL_CONNECTION_ACK: 'connection_ack', // Server -> Client
@@ -16,7 +19,7 @@ module.exports.getProtocolByName = function (name) {
         GQL_DATA: 'next', // Server -> Client
         GQL_ERROR: 'error', // Server -> Client
         GQL_COMPLETE: 'complete', // Server -> Client
-        GQL_STOP: 'stop' // Client -> Server
+        GQL_STOP: 'complete' // Client -> Server
       }
     case (name.indexOf(GRAPHQL_WS) !== -1):
       return {

--- a/test/subscription-protocol.js
+++ b/test/subscription-protocol.js
@@ -26,7 +26,7 @@ test('getProtocolByName returns correct protocol message types', t => {
     GQL_DATA: 'next',
     GQL_ERROR: 'error',
     GQL_COMPLETE: 'complete',
-    GQL_STOP: 'stop'
+    GQL_STOP: 'complete'
   })
   t.equal(getProtocolByName('unsupported-protocol'), null)
 })


### PR DESCRIPTION
Closes https://github.com/mercurius-js/mercurius/issues/629

Let me know if the unit-tests should be structured differently. Or if you want me to extend the PR and add tests for all the message types of `graphql-transport-ws`.