### PR TITLE
feat: add modifiedSchema on preExecution hooks

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -64,6 +64,8 @@ In the `preExecution` hook, you can modify the following items by returning them
   - `schema`
   - `errors`
 
+Note that when the `schama` is modified, the query is not [jit'ed nor counted](./api/options.md#plugin-options).
+
 ```js
 fastify.graphql.addHook('preExecution', async (schema, document, context) => {
   const { modifiedSchema, modifiedDocument, errors } = await asyncMethod(document)

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -61,13 +61,15 @@ fastify.graphql.addHook('preValidation', async (schema, document, context) => {
 
 In the `preExecution` hook, you can modify the following items by returning them in the hook definition:
   - `document`
+  - `schema`
   - `errors`
 
 ```js
 fastify.graphql.addHook('preExecution', async (schema, document, context) => {
-  const { modifiedDocument, errors } = await asyncMethod(document)
+  const { modifiedSchema, modifiedDocument, errors } = await asyncMethod(document)
 
   return {
+    schema: modifiedSchema, // ⚠️ changing the schema may break the query execution. Use it carefully.
     document: modifiedDocument,
     errors
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -786,6 +786,7 @@ type ValidationRules =
     }) => ValidationRule[]);
 
 export interface PreExecutionHookResponse<TError extends Error> {
+  schema?: GraphQLSchema
   document?: DocumentNode
   errors?: TError[]
 }

--- a/index.js
+++ b/index.js
@@ -164,9 +164,9 @@ const plugin = fp(async function (app, opts) {
       }),
       mutation: opts.defineMutation
         ? new GraphQLObjectType({
-          name: 'Mutation',
-          fields: {}
-        })
+            name: 'Mutation',
+            fields: {}
+          })
         : undefined
     })
   }

--- a/index.js
+++ b/index.js
@@ -534,11 +534,8 @@ const plugin = fp(async function (app, opts) {
     }
 
     // minJit is 0 by default
-    if (shouldCompileJit) {
-      cached.jit = compileQuery(
-        modifiedSchema || fastifyGraphQl.schema,
-        modifiedDocument || document, operationName
-      )
+    if (shouldCompileJit && !modifiedSchema) {
+      cached.jit = compileQuery(fastifyGraphQl.schema, modifiedDocument || document, operationName)
     }
 
     if (cached && cached.jit !== null) {

--- a/index.js
+++ b/index.js
@@ -527,14 +527,18 @@ const plugin = fp(async function (app, opts) {
     }
 
     // Trigger preExecution hook
+    let modifiedSchema
     let modifiedDocument
     if (context.preExecution !== null) {
-      ({ modifiedDocument } = await preExecutionHandler({ schema: fastifyGraphQl.schema, document, context }))
+      ({ modifiedSchema, modifiedDocument } = await preExecutionHandler({ schema: fastifyGraphQl.schema, document, context }))
     }
 
     // minJit is 0 by default
     if (shouldCompileJit) {
-      cached.jit = compileQuery(fastifyGraphQl.schema, modifiedDocument || document, operationName)
+      cached.jit = compileQuery(
+        modifiedSchema || fastifyGraphQl.schema,
+        modifiedDocument || document, operationName
+      )
     }
 
     if (cached && cached.jit !== null) {
@@ -544,7 +548,7 @@ const plugin = fp(async function (app, opts) {
     }
 
     const execution = await execute(
-      fastifyGraphQl.schema,
+      modifiedSchema || fastifyGraphQl.schema,
       modifiedDocument || document,
       root,
       context,

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -37,12 +37,13 @@ async function preExecutionHandler (request) {
     addErrorsToContext(request.context, errors)
   }
   if (typeof modifiedDocument !== 'undefined' || typeof modifiedSchema !== 'undefined') {
-    return {
-      modifiedSchema,
-      modifiedDocument,
-      modifiedQuery: print(request.document)
-    }
+    return Object.create(null, {
+      modifiedDocument: { value: modifiedDocument },
+      modifiedSchema: { value: modifiedSchema },
+      modifiedQuery: { get: () => print(modifiedDocument || request.document) }
+    })
   }
+
   return {}
 }
 
@@ -55,7 +56,10 @@ async function preGatewayExecutionHandler (request) {
     addErrorsToContext(request.context, errors)
   }
   if (typeof modifiedDocument !== 'undefined') {
-    return { modifiedDocument, modifiedQuery: print(modifiedDocument) }
+    return Object.create(null, {
+      modifiedDocument: { value: modifiedDocument },
+      modifiedQuery: { get: () => print(modifiedDocument) }
+    })
   }
   return {}
 }

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -29,15 +29,19 @@ async function preValidationHandler (request) {
 }
 
 async function preExecutionHandler (request) {
-  const { errors, modifiedDocument } = await preExecutionHooksRunner(
+  const { errors, modifiedDocument, modifiedSchema } = await preExecutionHooksRunner(
     request.context.preExecution,
     request
   )
   if (errors.length > 0) {
     addErrorsToContext(request.context, errors)
   }
-  if (typeof modifiedDocument !== 'undefined') {
-    return { modifiedDocument, modifiedQuery: print(request.document) }
+  if (typeof modifiedDocument !== 'undefined' || typeof modifiedSchema !== 'undefined') {
+    return {
+      modifiedSchema,
+      modifiedDocument,
+      modifiedQuery: print(request.document)
+    }
   }
   return {}
 }

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -39,8 +39,7 @@ async function preExecutionHandler (request) {
   if (typeof modifiedDocument !== 'undefined' || typeof modifiedSchema !== 'undefined') {
     return Object.create(null, {
       modifiedDocument: { value: modifiedDocument },
-      modifiedSchema: { value: modifiedSchema },
-      modifiedQuery: { get: () => print(modifiedDocument || request.document) }
+      modifiedSchema: { value: modifiedSchema }
     })
   }
 

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -87,12 +87,19 @@ async function hooksRunner (functions, runner, request) {
 
 async function preExecutionHooksRunner (functions, request) {
   let errors = []
+  let modifiedSchema
   let modifiedDocument
 
   for (const fn of functions) {
-    const result = await fn(request.schema, modifiedDocument || request.document, request.context)
+    const result = await fn(modifiedSchema || request.schema,
+      modifiedDocument || request.document,
+      request.context
+    )
 
     if (result) {
+      if (typeof result.schema !== 'undefined') {
+        modifiedSchema = result.schema
+      }
       if (typeof result.document !== 'undefined') {
         modifiedDocument = result.document
       }
@@ -102,7 +109,7 @@ async function preExecutionHooksRunner (functions, request) {
     }
   }
 
-  return { errors, modifiedDocument }
+  return { errors, modifiedDocument, modifiedSchema }
 }
 
 async function preGatewayExecutionHooksRunner (functions, request) {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "unit": "tap test/*.js test/gateway/*.js test/internals/*.js",
     "cov": "tap  --coverage-report=html -J test/*.js test/gateway/*.js",
     "lint": "npm run lint:standard && npm run lint:typescript",
+    "lint:fix": "standard --fix",
     "lint:standard": "standard | snazzy",
     "lint:typescript": "standard --parser @typescript-eslint/parser --plugin @typescript-eslint/eslint-plugin test/types/*.ts",
     "typescript": "tsd",

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -537,6 +537,7 @@ app.graphql.addHook('preExecution', async function (schema, document, context) {
   expectAssignable<DocumentNode>(document)
   expectAssignable<MercuriusContext>(context)
   return {
+    schema,
     document,
     errors: [
       new Error('foo')


### PR DESCRIPTION
Opening this PR to get some feedback.

I'm working on this issue: https://github.com/mercurius-js/auth/issues/43
The target of that issue is to modify the output schema for inspection queries like so

```js
app.graphql.addHook('preExecution', async function filterHook (schema, document, context) {

  // removes those objects that the user has not access to
  const filteredSchema = auth.filterDirectives(schema, authSchema)

  return {
    schema: filteredSchema
  }
})
```

The inspection query is a standard query that is being executed on the `app.graphql.schema` object.

To let the user (and in this case the mercurius/auth plugin) change the schema where the query is executed and affect the output results, the `preExecution` hook may manage a schema replacing.

Note that I did not use `app.graphql.transformSchema` because it would replace the initial/original schema: this is unwanted: the target here is to replace the schema only for a single request execution.

Doing so, every request may change the schema accordingly to its data (such as client's role&permissions).

This PR lacks documentation, but I would like to know if you are OK with this solution before add it.
Feel free to suggest some additional tests too

Thanks
