### PR TITLE
compatibility: schema validation in gateway mode 

### DIFF
--- a/lib/federation.js
+++ b/lib/federation.js
@@ -276,6 +276,16 @@ function buildFederationSchema (schema, isGateway) {
   const parsedOriginalSchema = parse(schema)
   const { typeStubs, extensions, definitions } = getStubTypes(parsedOriginalSchema.definitions, isGateway)
 
+  // before we validate the federationSchema, we want to remove the _service field from the extended query,
+  // if there is one, as this field should be excluded from the validation to provide broader support
+  // for different federation implementations => https://github.com/mercurius-js/mercurius/issues/643
+  const filteredExtensions = extensions.map(extension => {
+    if (extension.name.value === 'Query') {
+      extension.fields = extension.fields.filter(field => field.name.value !== '_service')
+    }
+    return extension
+  })
+
   // Add type stubs - only needed for federation
   federationSchema = extendSchema(federationSchema, {
     kind: Kind.DOCUMENT,
@@ -291,7 +301,7 @@ function buildFederationSchema (schema, isGateway) {
   // Add all extensions
   const extensionsDocument = {
     kind: Kind.DOCUMENT,
-    definitions: extensions
+    definitions: filteredExtensions
   }
 
   // instead of relying on extendSchema internal validations

--- a/test/gateway/schema.js
+++ b/test/gateway/schema.js
@@ -2458,3 +2458,299 @@ test('Update the schema without any changes', async (t) => {
 
   t.equal(newSchema, null)
 })
+
+test('It builds the gateway schema correctly with two services query extension having the _service fields', async (t) => {
+  const users = {
+    u1: {
+      id: 'u1',
+      name: 'John'
+    },
+    u2: {
+      id: 'u2',
+      name: 'Jane'
+    },
+    u3: {
+      id: 'u3',
+      name: 'Jack'
+    }
+  }
+
+  const posts = {
+    p1: {
+      pid: 'p1',
+      title: 'Post 1',
+      content: 'Content 1',
+      authorId: 'u1'
+    },
+    p2: {
+      pid: 'p2',
+      title: 'Post 2',
+      content: 'Content 2',
+      authorId: 'u2'
+    },
+    p3: {
+      pid: 'p3',
+      title: 'Post 3',
+      content: 'Content 3',
+      authorId: 'u1'
+    },
+    p4: {
+      pid: 'p4',
+      title: 'Post 4',
+      content: 'Content 4',
+      authorId: 'u2'
+    }
+  }
+
+  const [userService, userServicePort] = await createService(t, `
+    directive @customDirective on FIELD_DEFINITION
+
+    type _Service {
+      sdl: String
+    }
+
+    extend type Query {
+      me: User
+      hello: String
+      _service: _Service!
+    }
+
+    type User @key(fields: "id") {
+      id: ID!
+      name: String!
+      avatar(size: AvatarSize): String
+      friends: [User]
+    }
+
+    enum AvatarSize {
+      small
+      medium
+      large
+    }
+  `, {
+    Query: {
+      me: (root, args, context, info) => {
+        return users.u1
+      },
+      hello: () => 'World'
+    },
+    User: {
+      __resolveReference: (user, args, context, info) => {
+        return users[user.id]
+      },
+      avatar: (user, { size }) => `avatar-${size}.jpg`,
+      friends: (user) => Object.values(users).filter(u => u.id !== user.id)
+    }
+  })
+
+  const [postService, postServicePort] = await createService(t, `
+    type Post @key(fields: "pid") {
+      pid: ID!
+      title: String
+      content: String
+      author: User @requires(fields: "title")
+    }
+
+    type _Service {
+      sdl: String
+    }
+
+    extend type Query {
+      topPosts(count: Int): [Post]
+      _service: _Service!
+    }
+
+    type User @key(fields: "id") @extends {
+      id: ID! @external
+      name: String @external
+      posts: [Post]
+      numberOfPosts: Int @requires(fields: "id")
+    }
+  `, {
+    Post: {
+      __resolveReference: (post, args, context, info) => {
+        return posts[post.pid]
+      },
+      author: (post, args, context, info) => {
+        return {
+          __typename: 'User',
+          id: post.authorId
+        }
+      }
+    },
+    User: {
+      posts: (user, args, context, info) => {
+        return Object.values(posts).filter(p => p.authorId === user.id)
+      },
+      numberOfPosts: (user) => {
+        return Object.values(posts).filter(p => p.authorId === user.id).length
+      }
+    },
+    Query: {
+      topPosts: (root, { count = 2 }) => Object.values(posts).slice(0, count)
+    }
+  })
+
+  const gateway = Fastify()
+  t.teardown(async () => {
+    await gateway.close()
+    await postService.close()
+    await userService.close()
+  })
+  gateway.register(GQL, {
+    gateway: {
+      services: [{
+        name: 'user',
+        url: `http://localhost:${userServicePort}/graphql`,
+        rewriteHeaders: (headers) => {
+          if (headers.authorization) {
+            return {
+              authorization: headers.authorization
+            }
+          }
+        }
+      }, {
+        name: 'post',
+        url: `http://localhost:${postServicePort}/graphql`
+      }]
+    }
+  })
+
+  const query = `
+  query MainQuery(
+    $size: AvatarSize
+    $count: Int
+  ) {
+    me {
+      id
+      name
+      avatar(size: $size)
+      friends {
+        ...UserFragment
+        friends {
+          ...UserFragment
+        }
+      }
+      posts {
+        ...PostFragment
+      }
+      numberOfPosts
+    }
+    topPosts(count: $count) {
+      ...PostFragment
+    }
+    hello
+  }
+
+  fragment UserFragment on User {
+    id
+    name
+    avatar(size: medium)
+    numberOfPosts
+  }
+
+  fragment PostFragment on Post {
+    pid
+    title
+    content
+    ...AuthorFragment
+  }
+  
+  fragment AuthorFragment on Post {
+    author {
+      ...UserFragment
+    }
+  }`
+  const res = await gateway.inject({
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: 'bearer supersecret'
+    },
+    url: '/graphql',
+    body: JSON.stringify({
+      query,
+      variables: {
+        size: 'small',
+        count: 1
+      }
+    })
+  })
+
+  t.same(JSON.parse(res.body), {
+    data: {
+      me: {
+        id: 'u1',
+        name: 'John',
+        avatar: 'avatar-small.jpg',
+        friends: [{
+          id: 'u2',
+          name: 'Jane',
+          avatar: 'avatar-medium.jpg',
+          numberOfPosts: 2,
+          friends: [{
+            id: 'u1',
+            name: 'John',
+            avatar: 'avatar-medium.jpg',
+            numberOfPosts: 2
+          }, {
+            id: 'u3',
+            name: 'Jack',
+            avatar: 'avatar-medium.jpg',
+            numberOfPosts: 0
+          }]
+        }, {
+          id: 'u3',
+          name: 'Jack',
+          avatar: 'avatar-medium.jpg',
+          numberOfPosts: 0,
+          friends: [{
+            id: 'u1',
+            name: 'John',
+            avatar: 'avatar-medium.jpg',
+            numberOfPosts: 2
+          }, {
+            id: 'u2',
+            name: 'Jane',
+            avatar: 'avatar-medium.jpg',
+            numberOfPosts: 2
+          }]
+        }],
+        posts: [{
+          pid: 'p1',
+          title: 'Post 1',
+          content: 'Content 1',
+          author: {
+            id: 'u1',
+            name: 'John',
+            avatar: 'avatar-medium.jpg',
+            numberOfPosts: 2
+          }
+        }, {
+          pid: 'p3',
+          title: 'Post 3',
+          content: 'Content 3',
+          author: {
+            id: 'u1',
+            name: 'John',
+            avatar: 'avatar-medium.jpg',
+            numberOfPosts: 2
+          }
+        }],
+        numberOfPosts: 2
+      },
+      topPosts: [{
+        pid: 'p1',
+        title: 'Post 1',
+        content: 'Content 1',
+        author: {
+          id: 'u1',
+          name: 'John',
+          avatar: 'avatar-medium.jpg',
+          numberOfPosts: 2
+        }
+      }],
+      hello: 'World'
+    }
+  })
+})


### PR DESCRIPTION
Added a filter on the query extensions in the schema create. 
This filter removes all the _service fields in the extend queries. 
This will help to be compatible with multiple services in gateway mode that do not remove the _service field in the SDL while still supporting federation.


see:
https://github.com/mercurius-js/mercurius/issues/643