### PR TITLE
fix: upgrade to graphql v16 WIP

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -165,9 +165,9 @@ module.exports = async function (app, opts) {
     notSupportedError
   } = persistedQueryProvider || {}
 
-  async function executeQuery (query, variables, operationName, request, reply) {
+  async function executeQuery ({ source, variableValues, operationName, request, reply }) {
     // Validate a query is present
-    if (!query) {
+    if (!source) {
       return new MER_ERR_GQL_PERSISTED_QUERY_NOT_FOUND('Unknown query')
     }
 
@@ -178,17 +178,24 @@ module.exports = async function (app, opts) {
     }
 
     // Handle the query, throwing an error if required
-    return reply.graphql(query, Object.assign(context, { pubsub: subscriber, __currentQuery: query }), variables, operationName)
+    return reply.graphql({
+      source,
+      contextValue: Object.assign(context, { pubsub: subscriber, __currentQuery: source }),
+      variableValues,
+      operationName
+    })
   }
 
   function executeRegularQuery (body, request, reply) {
-    const { query, operationName, variables } = body
-    return executeQuery(query, variables, operationName, request, reply)
+    const { query: source, operationName, variables: variableValues } = body
+    return executeQuery({
+      source, variableValues, operationName, request, reply
+    })
   }
 
   async function executePersistedQuery (body, request, reply) {
-    let { query } = body
-    const { operationName, variables } = body
+    let { query: source } = body
+    const { operationName, variables: variableValues } = body
 
     // Verify if a query matches the persisted format
     const persisted = isPersistedQuery(body)
@@ -200,9 +207,9 @@ module.exports = async function (app, opts) {
       const hash = getHash && getHash(body)
       if (hash) {
         // Load the query for the provided hash
-        query = await getQueryFromHash(hash)
+        source = await getQueryFromHash(hash)
 
-        if (!query) {
+        if (!source) {
           // Query has not been found, tell the client
           throw new MER_ERR_GQL_PERSISTED_QUERY_NOT_FOUND(notFoundError)
         }
@@ -216,17 +223,19 @@ module.exports = async function (app, opts) {
     }
 
     // Execute the query
-    const result = await executeQuery(query, variables, operationName, request, reply)
+    const result = await executeQuery({
+      source, variableValues, operationName, request, reply
+    })
 
     // Only save queries which are not yet persisted
-    if (!persisted && query) {
+    if (!persisted && source) {
       // If provided the getHashForQuery, saveQuery settings we save this query
-      const hash = getHashForQuery && getHashForQuery(query)
+      const hash = getHashForQuery && getHashForQuery(source)
       if (hash) {
         try {
-          await saveQuery(hash, query)
+          await saveQuery(hash, source)
         } catch (err) {
-          request.log.warn({ err, hash, query }, 'Failed to persist query')
+          request.log.warn({ err, hash, source }, 'Failed to persist query')
         }
       }
     }

--- a/lib/subscription-connection.js
+++ b/lib/subscription-connection.js
@@ -183,11 +183,11 @@ module.exports = class SubscriptionConnection {
       subscriptionLoaders = this.fastify[kSubscriptionFactory]
     }
 
-    const subIter = await subscribe(
+    const subIter = await subscribe({
       schema,
       document,
-      {}, // rootValue
-      {
+      rootValue: {},
+      contextValue: {
         ...context,
         get __currentQuery () {
           return print(document)
@@ -201,9 +201,9 @@ module.exports = class SubscriptionConnection {
           [kEntityResolvers]: this.entityResolvers
         }
       },
-      variables,
+      variableValues: variables,
       operationName
-    )
+    })
     this.subscriptionIters.set(id, subIter)
 
     if (subIter.errors) {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "concurrently": "^6.2.0",
     "docsify-cli": "^4.4.3",
     "fastify": "^3.18.1",
-    "graphql-middleware": "^6.1.12",
     "graphql-shield": "^7.5.0",
     "graphql-tools": "^8.0.0",
     "pre-commit": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://mercurius.dev",
   "peerDependencies": {
-    "graphql": "^15.5.1"
+    "graphql": "^16.0.1"
   },
   "devDependencies": {
     "@graphql-tools/merge": "^8.0.0",
@@ -61,7 +61,7 @@
     "fastify-plugin": "^3.0.0",
     "fastify-static": "^4.2.2",
     "fastify-websocket": "^4.0.0",
-    "graphql": "^15.5.1",
+    "graphql": "^16.0.1",
     "graphql-jit": "^0.7.0",
     "mqemitter": "^4.4.1",
     "p-map": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "graphql": "^16.0.1"
   },
   "devDependencies": {
-    "@graphql-tools/merge": "^8.0.0",
-    "@graphql-tools/schema": "^8.0.0",
-    "@graphql-tools/utils": "^8.0.0",
+    "@graphql-tools/merge": "^8.2.1",
+    "@graphql-tools/schema": "^8.3.1",
+    "@graphql-tools/utils": "^8.5.3",
     "@sinonjs/fake-timers": "^8.0.1",
     "@types/node": "^16.0.0",
     "@types/ws": "^8.2.0",
@@ -40,7 +40,7 @@
     "concurrently": "^6.2.0",
     "docsify-cli": "^4.4.3",
     "fastify": "^3.18.1",
-    "graphql-tools": "^8.0.0",
+    "graphql-tools": "^8.2.0",
     "pre-commit": "^1.2.2",
     "proxyquire": "^2.1.3",
     "snazzy": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "concurrently": "^6.2.0",
     "docsify-cli": "^4.4.3",
     "fastify": "^3.18.1",
-    "graphql-shield": "^7.5.0",
     "graphql-tools": "^8.0.0",
     "pre-commit": "^1.2.2",
     "proxyquire": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "concurrently": "^6.2.0",
     "docsify-cli": "^4.4.3",
     "fastify": "^3.18.1",
-    "graphql-middleware": "^6.0.10",
+    "graphql-middleware": "^6.1.12",
     "graphql-shield": "^7.5.0",
     "graphql-tools": "^8.0.0",
     "pre-commit": "^1.2.2",

--- a/test/app-decorator.js
+++ b/test/app-decorator.js
@@ -65,7 +65,7 @@ test('support context in resolver', async (t) => {
   await app.ready()
 
   const query = '{ ctx }'
-  const res = await app.graphql(query, { num: 42 })
+  const res = await app.graphql({ query, contextValue: { num: 42 } })
 
   t.same(res, {
     data: {

--- a/test/directives.js
+++ b/test/directives.js
@@ -121,12 +121,12 @@ test('custom directives should work', async (t) => {
   const app = Fastify()
   const schema = `
     ${upperDirectiveTypeDefs}
-    
+
     type Query {
       foo: String @upper
       user: User
     }
-    
+
     type User {
       id: ID!
       name: String @upper
@@ -168,12 +168,12 @@ test('custom directives should work with single transform function', async (t) =
   const app = Fastify()
   const schema = `
     ${upperDirectiveTypeDefs}
-    
+
     type Query {
       foo: String @upper
       user: User
     }
-    
+
     type User {
       id: ID!
       name: String @upper
@@ -215,12 +215,12 @@ test('custom directives should work with executable schema', async (t) => {
   const app = Fastify()
   const schema = `
     ${upperDirectiveTypeDefs}
-    
+
     type Query {
       foo: String @upper
       user: User
     }
-    
+
     type User {
       id: ID!
       name: String @upper
@@ -384,12 +384,12 @@ test('federation support and custom directives', async (t) => {
   const app = Fastify()
   const schema = `
     ${upperDirectiveTypeDefs}
-    
+
     type Query {
       foo: String @upper
       user: User
     }
-    
+
     type User {
       id: ID!
       name: String @upper
@@ -436,7 +436,7 @@ test('federation support using schema from buildFederationSchema and custom dire
   const app = Fastify()
   const schema = `
     ${upperDirectiveTypeDefs}
-    
+
     type Query {
       foo: String @upper
     }
@@ -479,16 +479,16 @@ test('max length directive validation works', async (t) => {
       foo(value: String!): String @length(max: 5)
       user(id: ID!): User
     }
-    
+
     type Mutation {
       createUser(input: CreateUserInput!): User!
     }
-    
+
     type User {
       id: ID!
       name: String @length(max: 5)
     }
-    
+
     input CreateUserInput {
       id: ID!
       name: String! @length(max: 3)

--- a/test/errors.js
+++ b/test/errors.js
@@ -703,11 +703,11 @@ test('app.graphql which throws, with JIT enabled, twice', async (t) => {
         bad
     }`
 
-  let res = await app.graphql(query, null, { x: 1 })
+  let res = await app.graphql({ query, contextValue: { x: 1 } })
 
   t.matchSnapshot(JSON.stringify(res), null, 2)
 
-  res = await app.graphql(query, null, { x: 1 })
+  res = await app.graphql({ query, contextValue: { x: 1 } })
 
   t.matchSnapshot(JSON.stringify(res), null, 2)
 

--- a/test/validation-rules.js
+++ b/test/validation-rules.js
@@ -45,7 +45,7 @@ test('validationRules array - reports an error', async (t) => {
   await app.ready()
 
   try {
-    await app.graphql(query)
+    await app.graphql({ source: query })
   } catch (e) {
     t.equal(e.errors.length, 1)
     t.equal(e.errors[0].message, 'Validation rule error')
@@ -74,7 +74,7 @@ test('validationRules array - passes when no errors', async (t) => {
   // needed so that graphql is defined
   await app.ready()
 
-  const res = await app.graphql(query)
+  const res = await app.graphql({ source: query })
   t.same(res, { data: { add: 4 } })
 })
 
@@ -91,7 +91,7 @@ test('validationRules array - works with empty validationRules', async (t) => {
   // needed so that graphql is defined
   await app.ready()
 
-  const res = await app.graphql(query)
+  const res = await app.graphql({ source: query })
   t.same(res, { data: { add: 4 } })
 })
 
@@ -119,7 +119,7 @@ test('validationRules - reports an error', async (t) => {
   await app.ready()
 
   try {
-    await app.graphql(query)
+    await app.graphql({ source: query })
   } catch (e) {
     t.equal(e.errors.length, 1)
     t.equal(e.errors[0].message, 'Validation rule error')
@@ -149,7 +149,7 @@ test('validationRules - passes when no errors', async (t) => {
   // needed so that graphql is defined
   await app.ready()
 
-  const res = await app.graphql(query)
+  const res = await app.graphql({ source: query })
   t.same(res, { data: { add: 4 } })
 })
 
@@ -167,7 +167,7 @@ test('validationRules - works with empty validationRules', async (t) => {
   // needed so that graphql is defined
   await app.ready()
 
-  const res = await app.graphql(query)
+  const res = await app.graphql({ source: query })
   t.same(res, { data: { add: 4 } })
 })
 
@@ -184,7 +184,7 @@ test('validationRules - works with missing validationRules', async (t) => {
   // needed so that graphql is defined
   await app.ready()
 
-  const res = await app.graphql(query)
+  const res = await app.graphql({ source: query })
   t.same(res, { data: { add: 4 } })
 })
 
@@ -202,9 +202,9 @@ test('validationRules - includes graphql request metadata', async (t) => {
     schema,
     resolvers,
     cache: false,
-    validationRules: function ({ source, variables, operationName }) {
+    validationRules: function ({ source, variableValues, operationName }) {
       t.equal(source, query)
-      t.same(variables, { x: 2, y: 2 })
+      t.same(variableValues, { x: 2, y: 2 })
       t.same(operationName, 'Add')
       return [
         // validation rule that reports no errors
@@ -222,7 +222,11 @@ test('validationRules - includes graphql request metadata', async (t) => {
   // needed so that graphql is defined
   await app.ready()
 
-  const res = await app.graphql(query, null, { x: 2, y: 2 }, 'Add')
+  const res = await app.graphql({
+    source: query,
+    variableValues: { x: 2, y: 2 },
+    operationName: 'Add'
+  })
   t.same(res, { data: { add: 4 } })
 })
 


### PR DESCRIPTION
Breaking changes in GraphQL v16 need work.
I started updating invocations of `execute` function to the new signature.
That made more unit tests passing... but now many of them fail with a body that contains:

`Cannot read properties of undefined (reading 'fields')`.

At the moment I don't have a clear idea where this is coming from and I'll ask for help.
I hence committed with "-n" just to share current progress.