### PR TITLE
Polishing/error formatter context

### DIFF
--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -49,7 +49,7 @@
 - `prefix`: String. Change the route prefix of the graphql endpoint if enabled.
 - `defineMutation`: Boolean. Add the empty Mutation definition if schema is not defined (Default: `false`).
 - `errorHandler`: `Function`  or `boolean`. Change the default error handler (Default: `true`). _Note: If a custom error handler is defined, it should return the standardized response format according to [GraphQL spec](https://graphql.org/learn/serving-over-http/#response)._
-- `errorFormatter`: `Function`. Change the default error formatter. Allows the status code of the response to be set, and a GraphQL response for the error to be defined. This can be used to format errors for batched queries, which return a successful response overall but individual errors, or to obfuscate or format internal errors. The first argument is the error object, while the second one _might_ be the context if it is available.
+- `errorFormatter`: `Function`. Change the default error formatter. Allows the status code of the response to be set, and a GraphQL response for the error to be defined. This can be used to format errors for batched queries, which return a successful response overall but individual errors, or to obfuscate or format internal errors. The first argument is the error object, while the second one is the context object.
 - `queryDepth`: `Integer`. The maximum depth allowed for a single query. _Note: GraphiQL IDE sends an introspection query when it starts up. This query has a depth of 7 so when the `queryDepth` value is smaller than 7 this query will fail with a `Bad Request` error_
 - `validationRules`: `Function` or `Function[]`. Optional additional validation rules that the queries must satisfy in addition to those defined by the GraphQL specification. When using `Function`, arguments include additional data from graphql request and the return value must be validation rules `Function[]`.
 - `subscription`: Boolean | Object. Enable subscriptions. It uses [mqemitter](https://github.com/mcollina/mqemitter) when it is true and exposes the pubsub interface to `app.graphql.pubsub`. To use a custom emitter set the value to an object containing the emitter.
@@ -553,6 +553,6 @@ To control the status code for the response, the third optional parameter can be
 
 Allows the status code of the response to be set, and a GraphQL response for the error to be defined. 
 
-By default uses the defaultErrorFormatter, but it can be overridden in the [mercurius options](/docs/api/options.md#plugin-options) changing the errorFormatter parameter.
+By default uses the `defaultErrorFormatter`, but it can be overridden in the [mercurius options](/docs/api/options.md#plugin-options) changing the errorFormatter parameter.
 
 **Important**: *using the default formatter, when the error has a data property the response status code will be always 200*

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -63,18 +63,13 @@ function toGraphQLError (err) {
 
 function defaultErrorFormatter (err, ctx) {
   let errors = [{ message: err.message }]
-  let log
-
-  if (ctx) {
-    // There is always app if there is a context
-    log = ctx.reply ? ctx.reply.log : ctx.app.log
-  }
+  // There is always app if there is a context
+  const log = ctx.reply ? ctx.reply.log : ctx.app.log
 
   if (err.errors) {
     errors = err.errors.map((error, idx) => {
-      if (log) {
-        log.error({ err: error }, error.message)
-      }
+      log.error({ err: error }, error.message)
+
       // parses, converts & combines errors if they are the result of a federated request
       if (error.message === FEDERATED_ERROR.toString()) {
         return error.extensions.errors.map(err => formatError(toGraphQLError(err)))

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -136,13 +136,17 @@ module.exports = async function (app, opts) {
     app.setErrorHandler(opts.errorHandler)
   } else if (opts.errorHandler === true || opts.errorHandler === undefined) {
     app.setErrorHandler((error, request, reply) => {
-      const context = request[kRequestContext]
-      const { statusCode, response } = errorFormatter(error, context)
+      const { statusCode, response } = errorFormatter(
+        error,
+        request[kRequestContext]
+      )
       reply.code(statusCode).send(response)
     })
   }
   const contextFn = opts.context
   const { subscriptionContextFn } = opts
+
+  app.decorateRequest(kRequestContext)
 
   const {
     path: graphqlPath = '/graphql',
@@ -173,10 +177,16 @@ module.exports = async function (app, opts) {
       return new MER_ERR_GQL_PERSISTED_QUERY_NOT_FOUND('Unknown query')
     }
 
-    const context = request[kRequestContext]
-
     // Handle the query, throwing an error if required
-    return reply.graphql(query, Object.assign(context, { pubsub: subscriber, __currentQuery: query }), variables, operationName)
+    return reply.graphql(
+      query,
+      Object.assign(
+        request[kRequestContext],
+        { pubsub: subscriber, __currentQuery: query }
+      ),
+      variables,
+      operationName
+    )
   }
 
   function executeRegularQuery (body, request, reply) {
@@ -242,10 +252,12 @@ module.exports = async function (app, opts) {
     attachValidation: true,
     handler: async function (request, reply) {
       // Generate the context for this request
-      request[kRequestContext] = contextFn
-        ? await contextFn(request, reply)
-        : {}
-      Object.assign(request[kRequestContext], { reply, app })
+      if (contextFn) {
+        request[kRequestContext] = await contextFn(request, reply)
+        Object.assign(request[kRequestContext], { reply, app })
+      } else {
+        request[kRequestContext] = { reply, app }
+      }
 
       validationHandler(request.validationError)
 
@@ -284,10 +296,12 @@ module.exports = async function (app, opts) {
     attachValidation: true
   }, async function (request, reply) {
     // Generate the context for this request
-    const context = contextFn ? await contextFn(request, reply) : {}
-
-    request[kRequestContext] = context
-    Object.assign(request[kRequestContext], { reply, app })
+    if (contextFn) {
+      request[kRequestContext] = await contextFn(request, reply)
+      Object.assign(request[kRequestContext], { reply, app })
+    } else {
+      request[kRequestContext] = { reply, app }
+    }
 
     validationHandler(request.validationError)
 
@@ -296,7 +310,7 @@ module.exports = async function (app, opts) {
       return Promise.all(request.body.map(r =>
         execute(r, request, reply)
           .catch(e => {
-            const { response } = errorFormatter(e, context)
+            const { response } = errorFormatter(e, request[kRequestContext])
             return response
           })
       ))

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -3,6 +3,7 @@
 const { join } = require('path')
 const Static = require('fastify-static')
 const subscription = require('./subscription')
+const { kRequestContext } = require('./symbols')
 const sJSON = require('secure-json-parse')
 const {
   defaultErrorFormatter,
@@ -134,8 +135,9 @@ module.exports = async function (app, opts) {
   if (typeof opts.errorHandler === 'function') {
     app.setErrorHandler(opts.errorHandler)
   } else if (opts.errorHandler === true || opts.errorHandler === undefined) {
-    app.setErrorHandler((error, _, reply) => {
-      const { statusCode, response } = errorFormatter(error)
+    app.setErrorHandler((error, request, reply) => {
+      const context = request[kRequestContext]
+      const { statusCode, response } = errorFormatter(error, context)
       reply.code(statusCode).send(response)
     })
   }
@@ -171,11 +173,7 @@ module.exports = async function (app, opts) {
       return new MER_ERR_GQL_PERSISTED_QUERY_NOT_FOUND('Unknown query')
     }
 
-    // Generate the context for this request
-    let context = {}
-    if (contextFn) {
-      context = await contextFn(request, reply)
-    }
+    const context = request[kRequestContext]
 
     // Handle the query, throwing an error if required
     return reply.graphql(query, Object.assign(context, { pubsub: subscriber, __currentQuery: query }), variables, operationName)
@@ -243,6 +241,12 @@ module.exports = async function (app, opts) {
     schema: getSchema,
     attachValidation: true,
     handler: async function (request, reply) {
+      // Generate the context for this request
+      request[kRequestContext] = contextFn
+        ? await contextFn(request, reply)
+        : {}
+      Object.assign(request[kRequestContext], { reply, app })
+
       validationHandler(request.validationError)
 
       const { variables, extensions } = request.query
@@ -279,6 +283,12 @@ module.exports = async function (app, opts) {
     schema: postSchema(allowBatchedQueries),
     attachValidation: true
   }, async function (request, reply) {
+    // Generate the context for this request
+    const context = contextFn ? await contextFn(request, reply) : {}
+
+    request[kRequestContext] = context
+    Object.assign(request[kRequestContext], { reply, app })
+
     validationHandler(request.validationError)
 
     if (allowBatchedQueries && Array.isArray(request.body)) {
@@ -286,7 +296,7 @@ module.exports = async function (app, opts) {
       return Promise.all(request.body.map(r =>
         execute(r, request, reply)
           .catch(e => {
-            const { response } = errorFormatter(e)
+            const { response } = errorFormatter(e, context)
             return response
           })
       ))

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -4,7 +4,8 @@ const keys = {
   kLoaders: Symbol('mercurius.loaders'),
   kFactory: Symbol('mercurius.loadersFactory'),
   kSubscriptionFactory: Symbol('mercurius.subscriptionLoadersFactory'),
-  kHooks: Symbol('mercurius.hooks')
+  kHooks: Symbol('mercurius.hooks'),
+  kRequestContext: Symbol('mercurius.requestContext')
 }
 
 module.exports = keys

--- a/test/batched.js
+++ b/test/batched.js
@@ -111,6 +111,55 @@ test('POST single bad batched query', async (t) => {
   t.same(JSON.parse(res.body), [{ data: null, errors: [{ message: 'Syntax Error: Expected "$", found <EOF>.', locations: [{ line: 2, column: 37 }] }] }])
 })
 
+test('POST single bad batched query with cutom error formatter and custom async context', async (t) => {
+  t.plan(2)
+
+  const app = Fastify()
+
+  const schema = `
+      type Query {
+        add(x: Int, y: Int): Int
+      }
+    `
+
+  const resolvers = {
+    add: async ({ x, y }) => x + y
+  }
+
+  app.register(GQL, {
+    schema,
+    resolvers,
+    allowBatchedQueries: true,
+    context: async () => {
+      return { topic: 'NOTIFICATIONS_ADDED' }
+    },
+    errorFormatter: (_execution, context) => {
+      t.include(context, { topic: 'NOTIFICATIONS_ADDED' })
+      return {
+        response: {
+          data: null,
+          errors: [{ message: 'Internal Server Error' }]
+        }
+      }
+    }
+  })
+
+  const res = await app.inject({
+    method: 'POST',
+    url: '/graphql',
+    body: [
+      {
+        operationName: 'AddQuery',
+        variables: { x: 1, y: 2 },
+        query: `
+            query AddQuery ($x: Int!`
+      }
+    ]
+  })
+
+  t.same(JSON.parse(res.body), [{ data: null, errors: [{ message: 'Internal Server Error' }] }])
+})
+
 test('POST batched query', async (t) => {
   const app = Fastify()
 

--- a/test/routes.js
+++ b/test/routes.js
@@ -1655,7 +1655,11 @@ test('error thrown from onDisconnect is logged', t => {
   const error = new Error('error')
 
   const app = Fastify()
+
+  // override `app.log` to avoid poluting other tests
+  app.log = Object.create(app.log)
   app.log.error = (e) => { t.same(error, e) }
+
   t.teardown(() => app.close())
 
   const schema = `
@@ -1702,6 +1706,9 @@ test('promise rejection from onDisconnect is logged', t => {
   const error = new Error('error')
 
   const app = Fastify()
+
+  // override `app.log` to avoid poluting other tests
+  app.log = Object.create(app.log)
   app.log.error = (e) => { t.same(error, e) }
   t.teardown(() => app.close())
 


### PR DESCRIPTION
This is an implementation of the idea discussed in issue #616 .
According to types in `index.d.ts` custom error formatter should be always called with request context: https://github.com/mercurius-js/mercurius/blob/master/index.d.ts#L473

In reality, it sometimes was called with context, but sometimes without it.
This PR goal is to standardize this behavior and provide request context every time the error formatter is called.