### PR TITLE
Extend regression fix in handling bad json to include custom context

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -133,22 +133,33 @@ function tryJSONParse (request, value) {
 
 module.exports = async function (app, opts) {
   const errorFormatter = typeof opts.errorFormatter === 'function' ? opts.errorFormatter : defaultErrorFormatter
+  const contextFn = opts.context
 
   if (typeof opts.errorHandler === 'function') {
-    app.setErrorHandler((error, request, reply) => {
+    app.setErrorHandler(async (error, request, reply) => {
       const errorHandler = opts.errorHandler
       if (!request[kRequestContext]) {
         // Generate the context for this request
-        request[kRequestContext] = { reply, app }
+        if (contextFn) {
+          request[kRequestContext] = await contextFn(request, reply)
+          Object.assign(request[kRequestContext], { reply, app })
+        } else {
+          request[kRequestContext] = { reply, app }
+        }
       }
 
       return errorHandler(error, request, reply)
     })
   } else if (opts.errorHandler === true || opts.errorHandler === undefined) {
-    app.setErrorHandler((error, request, reply) => {
+    app.setErrorHandler(async (error, request, reply) => {
       if (!request[kRequestContext]) {
         // Generate the context for this request
-        request[kRequestContext] = { reply, app }
+        if (contextFn) {
+          request[kRequestContext] = await contextFn(request, reply)
+          Object.assign(request[kRequestContext], { reply, app })
+        } else {
+          request[kRequestContext] = { reply, app }
+        }
       }
 
       const { statusCode, response } = errorFormatter(
@@ -158,7 +169,6 @@ module.exports = async function (app, opts) {
       return reply.code(statusCode).send(response)
     })
   }
-  const contextFn = opts.context
   const { subscriptionContextFn } = opts
 
   app.decorateRequest(kRequestContext)


### PR DESCRIPTION
This PR extend #678 to include custom context in error formatter.

@mcollina I am not sure if context (custom and/or default) is needed in case when custom error handler has been used (as in is such case error formatter is not called at all with my understanding?)