### PR TITLE
fix: specify type better for context arg in defaultErrorFormatter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -614,7 +614,7 @@ declare namespace mercurius {
    */
   const defaultErrorFormatter: (
     execution: ExecutionResult,
-    context: any
+    context: MercuriusContext
   ) => { statusCode: number; response: ExecutionResult };
 
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -470,7 +470,7 @@ export interface MercuriusCommonOptions {
   /**
    * Change the default error formatter.
    */
-  errorFormatter?: <TContext extends Record<string,any> = MercuriusContext>(
+  errorFormatter?: <TContext extends MercuriusContext = MercuriusContext>(
     execution: ExecutionResult,
     context: TContext
   ) => {

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -629,3 +629,13 @@ declare module 'fastify' {
     graphql: MercuriusPlugin
   }
 }
+
+mercurius.defaultErrorFormatter({}, {} as MercuriusContext)
+
+expectError(() => {
+  return mercurius.defaultErrorFormatter({}, null)
+})
+
+expectError(() => {
+  return mercurius.defaultErrorFormatter({}, undefined)
+})


### PR DESCRIPTION
When context is null for example, it crashes with a type error
```
TypeError: Cannot read property 'reply' of null
    at AsyncFunction.defaultErrorFormatter (/home/capaj/work-repos/authier-repos/authier/node_modules/mercurius/lib/errors.js:67:19)
```