### PR TITLE
fix(): move graphql dependency back to dev deps 

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "concurrently": "^7.0.0",
     "docsify-cli": "^4.4.3",
     "fastify": "^3.18.1",
+    "graphql": "^16.0.0"
     "graphql-tools": "^8.0.0",
     "pre-commit": "^1.2.2",
     "proxyquire": "^2.1.3",
@@ -60,7 +61,6 @@
     "fastify-plugin": "^3.0.0",
     "fastify-static": "^4.2.2",
     "fastify-websocket": "^4.0.0",
-    "graphql": "^16.0.0",
     "graphql-jit": "^0.7.0",
     "mqemitter": "^4.4.1",
     "p-map": "^4.0.0",


### PR DESCRIPTION
## Current behavior

I've just noticed that the `graphql` package is currently defined as both "dependency" and a "peerDependency" (at the same time) which implicitly means it's no longer a "peer dependency" as it will be auto-installed by package managers as an internal mercurius' dependency.

This has been already fixed in the past but it was reverted back in this PR https://github.com/mercurius-js/mercurius/pull/565

## Expected behavior 

`graphql` should be listed as a `devDependency` so it gets auto-installed for those who want to contribute. For package consumers though, it should be defined as a peer dependency, otherwise, you may run into the following issue:

```text
Error: Cannot use GraphQLSchema "{ __validationErrors: [], description: undefined, extensions: undefined, astNode: undefined, extensionASTNodes: [], _queryType: Query, _mutationType: Mutation, _subscriptionType: Subscription, _directives: [@include, @skip, @deprecated, @specifiedBy], _typeMap: { Recipe: Recipe, ID: ID, String: String, Date: Date, Query: Query, Int: Int, Mutation: Mutation, NewRecipeInput: NewRecipeInput, Boolean: Boolean, Subscription: Subscription, __Schema: __Schema, __Type: __Type, __TypeKind: __TypeKind, __Field: __Field, __InputValue: __InputValue, __EnumValue: __EnumValue, __Directive: __Directive, __DirectiveLocation: __DirectiveLocation }, _subTypeMap: {}, _implementationsMap: {} }" from another module or realm.

Ensure that there is only one instance of "graphql" in the node_modules
directory. If different versions of "graphql" are the dependencies of other
relied on modules, use "resolutions" to ensure only one version is installed.

https://yarnpkg.com/en/docs/selective-version-resolutions

Duplicate "graphql" modules cannot be used at the same time since different
versions may have different capabilities and behavior. The data from one
version used in the function from another could produce confusing and
spurious results.
```

Great work on this package @mcollina!
