### PR TITLE
fix bug where some requests pass variables = {} instead of variables undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -536,8 +536,10 @@ const plugin = fp(async function (app, opts) {
     }
 
     const shouldCompileJit = cached && cached.count++ === minJit
+    const shouldValidateVariables = variables !== undefined && Object.keys(variables).length > 0
+
     // Validate variables
-    if (variables !== undefined && !shouldCompileJit) {
+    if (shouldValidateVariables && !shouldCompileJit) {
       const executionContext = buildExecutionContext({
         schema: fastifyGraphQl.schema,
         document,


### PR DESCRIPTION
I'm seeing an issue with fastify + mercurius where some GraphQL playgrounds / queries are getting parsed as `variables = {}` instead of the expected `variables = undefined`

Versions:
```
fastify 3.25.3
mercurius 9.1.0
```

This is most easily seen when using GraphQL Playground vs Insomnia:

Insomnia:
```
before buildExecutionContext {
  document: {
    kind: 'Document',
    definitions: [ [Object] ],
    loc: { start: 0, end: 46 }
  },
  variables: undefined,
  shouldCompileJit: undefined
}
```

vs GQL Playground (or Altair)

```
before buildExecutionContext {
  document: {
    kind: 'Document',
    definitions: [ [Object], [Object], [Object], [Object] ],
    loc: { start: 0, end: 1305 }
  },
  variables: {},
  shouldCompileJit: false
}
```

Notice the variable values are different. There's no difference in fastify implementation, just a difference with clients.

The difference in variables value is causing mercurius to blow up on document not being set inside `buildExecutionContext`

