### PR TITLE
Fixes issue with batchedQueries overriding loader

### DIFF
--- a/index.js
+++ b/index.js
@@ -305,7 +305,9 @@ const plugin = fp(async function (app, opts) {
 
     context = Object.assign(context, { reply: this, app })
     if (app[kFactory]) {
-      this[kLoaders] = app[kFactory].create(context)
+      if (!opts.allowBatchedQueries || !this[kLoaders]) {
+        this[kLoaders] = app[kFactory].create(context)
+      }
     }
 
     return app.graphql(source, context, variables, operationName)


### PR DESCRIPTION
When using `allowBatchedQueries` the loader would get overwritten for each query being processed
which would ultimately prevent the loaders being reuses for the whole batch.

The fix is pretty native, and only overwrittes the reply's loader if not provided if in allowBatchedQueries mode.

The behaviour for non `allowBatchedQueries` should be preserved.
