### PR TITLE
chore: remove unused `graphql-tools` dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "concurrently": "^7.0.0",
     "docsify-cli": "^4.4.3",
     "fastify": "^3.18.1",
-    "graphql-tools": "^8.0.0",
     "pre-commit": "^1.2.2",
     "proxyquire": "^2.1.3",
     "sinon": "^13.0.0",


### PR DESCRIPTION
Only the `@graphql-tools/*` dependencies are used.

```sh-session
$ rg graphql-tools
examples/executable-schema.js
5:const { makeExecutableSchema } = require('@graphql-tools/schema')

package.json
32:    "@graphql-tools/merge": "^8.0.0",
33:    "@graphql-tools/schema": "^8.0.0",
34:    "@graphql-tools/utils": "^8.0.0",

docs/api/options.md
335:const { makeExecutableSchema } = require('@graphql-tools/schema')

test/app-decorator.js
12:const { makeExecutableSchema } = require('@graphql-tools/schema')

test/directives.js
7:const { makeExecutableSchema } = require('@graphql-tools/schema')
8:const { mergeResolvers } = require('@graphql-tools/merge')
15:} = require('@graphql-tools/utils')

test/hooks.js
6:const { mapSchema } = require('@graphql-tools/utils')

test/types/index.ts
12:import { makeExecutableSchema } from '@graphql-tools/schema'
13:import { mapSchema } from '@graphql-tools/utils'
```