### PR TITLE
fix: typings for defaultErrorFormatter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -616,7 +616,7 @@ declare namespace mercurius {
    * Default error formatter.
    */
   const defaultErrorFormatter: (
-    execution: ExecutionResult,
+    execution: ExecutionResult | Error,
     context: MercuriusContext
   ) => { statusCode: number; response: ExecutionResult };
 

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -689,6 +689,8 @@ declare module 'fastify' {
 
 mercurius.defaultErrorFormatter({}, {} as MercuriusContext)
 
+mercurius.defaultErrorFormatter(new Error('test error'), {} as MercuriusContext)
+
 expectError(() => {
   return mercurius.defaultErrorFormatter({}, null)
 })


### PR DESCRIPTION
From what I can see the [initially suggested signature for defaultErrorFormatter](https://github.com/mercurius-js/mercurius/issues/196) was:

```
(err: Error | GraphQLError | FastifyError) => {
    statusCode: number
    response: {
      data: object
      errors: object[]
    }
 }
```

But somewhere down the line it became:

```
(
  execution: ExecutionResult,
  context: MercuriusContext
) => { statusCode: number; response: ExecutionResult };
```

However from [the JS code](https://github.com/mercurius-js/mercurius/blob/master/lib/errors.js) I can see that we're testing for [`instanceof ErrorWithProps`](https://github.com/mercurius-js/mercurius/blob/master/lib/errors.js#L46) and [`instanceof GraphQLError`](https://github.com/mercurius-js/mercurius/blob/master/lib/errors.js#L59) - both subclassed from `Error`.

This PR adds `Error` as a possible type for `execution` as it looks to be the common ancestor of what's tested for and in other cases have `message` prop.