### PR TITLE
fix: gateway empty types

### DIFF
--- a/lib/gateway/make-resolver.js
+++ b/lib/gateway/make-resolver.js
@@ -509,7 +509,7 @@ function makeResolver ({ service, createOperation, transformData, isQuery, isRef
       // TODO support union types
       const transformedTypeName = Array.isArray(transformed)
         ? transformed.length > 0 && transformed[0].__typename
-        : transformed.__typename
+        : transformed && transformed.__typename
       if (typeToServiceMap) {
         // If the type is defined in the typeToServiceMap, we need to resolve the type if the type is a reference
         // and it is fullfilled by another service

--- a/lib/gateway/make-resolver.js
+++ b/lib/gateway/make-resolver.js
@@ -507,7 +507,9 @@ function makeResolver ({ service, createOperation, transformData, isQuery, isRef
 
       const transformed = transformData(response)
       // TODO support union types
-      const transformedTypeName = Array.isArray(transformed) ? transformed[0].__typename : transformed.__typename
+      const transformedTypeName = Array.isArray(transformed)
+        ? transformed.length > 0 && transformed[0].__typename
+        : transformed.__typename
       if (typeToServiceMap) {
         // If the type is defined in the typeToServiceMap, we need to resolve the type if the type is a reference
         // and it is fullfilled by another service

--- a/test/gateway/fix-726.js
+++ b/test/gateway/fix-726.js
@@ -65,6 +65,7 @@ async function buildServiceExternal () {
       meWrap: Wrap
       meDirect: User
       meList: [User]
+      meEmptyList: [User]
     }
 
     type Wrap {
@@ -90,6 +91,10 @@ async function buildServiceExternal () {
           { id: '1', __typename: 'User' },
           { id: '2', __typename: 'User' }
         ]
+      },
+      meEmptyList: () => {
+        // no users
+        return []
       }
     },
     Wrap: {
@@ -248,6 +253,26 @@ test('federated node should be able to return external Type directly', async (t)
             name: 'Jane'
           }]
         }
+      }
+    })
+  }
+
+  {
+    const res = await serviceProxy.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: `{
+          meEmptyList { 
+            id name
+          }
+        }`
+      }
+    })
+
+    t.same(res.json(), {
+      data: {
+        meEmptyList: []
       }
     })
   }

--- a/test/gateway/fix-726.js
+++ b/test/gateway/fix-726.js
@@ -64,6 +64,7 @@ async function buildServiceExternal () {
     extend type Query {
       meWrap: Wrap
       meDirect: User
+      meDirectMissing: User
       meList: [User]
       meEmptyList: [User]
     }
@@ -85,6 +86,9 @@ async function buildServiceExternal () {
       },
       meDirect: () => {
         return { id: '1', __typename: 'User' }
+      },
+      meDirectMissing: () => {
+        return null
       },
       meList: () => {
         return [
@@ -173,6 +177,22 @@ test('federated node should be able to return external Type directly', async (t)
           name: 'John',
           username: '@john'
         }
+      }
+    })
+  }
+
+  {
+    const res = await serviceProxy.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: '{ meDirectMissing { id name username } }'
+      }
+    })
+
+    t.same(res.json(), {
+      data: {
+        meDirectMissing: null
       }
     })
   }


### PR DESCRIPTION
Follow up #726 

When the resolvers returns empty states (`null` or `[]`) an error is thrown
