### PR TITLE
fix: update graphql-jit

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "fastify-static": "^4.2.2",
     "fastify-websocket": "^4.0.0",
     "graphql": "^16.0.0",
-    "graphql-jit": "^0.7.0",
+    "graphql-jit": "^0.7.3",
     "mqemitter": "^4.4.1",
     "p-map": "^4.0.0",
     "promise.allsettled": "^1.0.4",


### PR DESCRIPTION
This resolves a peer dependency warning for graphql@16.

(I realise it's in semver range, but forcing the update so the dependency tree is guaranteed to be valid also after aggressive deduplication makes sense)