### PR TITLE
fix: gateway fragment usage

### DIFF
--- a/lib/gateway/make-resolver.js
+++ b/lib/gateway/make-resolver.js
@@ -441,18 +441,7 @@ function makeResolver ({ service, createOperation, transformData, isQuery, isRef
       // check if fragments are used in the original query
       const usedFragments = getFragmentNamesInSelection(selections)
       const fragmentsToDefine = collectFragmentsToInclude(usedFragments, fragments, service, schema)
-
-      /* istanbul ignore else */
-      if (fragmentsToDefine.length > 0) {
-        const fragmentsIncluded = new Set()
-        for (const fragment of fragmentsToDefine) {
-          if (!fragmentsIncluded.has(fragment.name.value)) {
-            query += `\n${print(fragment)}`
-            fragmentsIncluded.add(fragment.name.value)
-          }
-        }
-      }
-
+      query = appendFragments(query, fragmentsToDefine)
       lruGatewayResolvers.set(`${__currentQuery}_${resolverKey}`, { query, operation, variableNamesToDefine })
     }
 
@@ -530,6 +519,10 @@ function makeResolver ({ service, createOperation, transformData, isQuery, isRef
 
           query = print(operation)
 
+          const usedFragments = getFragmentNamesInSelection(selections)
+          const fragmentsToDefine = collectFragmentsToInclude(usedFragments, fragments, serviceMap[targetService], schema)
+          query = appendFragments(query, fragmentsToDefine)
+
           // We are completely skipping the resolver logic in this case to avoid expensive
           // multiple requests to the other service, one for each field. Our current logic
           // for the entities data loaders would not work in this case as we would need to
@@ -601,6 +594,21 @@ function getRequiredFields (obj, field) {
   }
 
   return result
+}
+
+function appendFragments (query, fragmentsToDefine) {
+  /* istanbul ignore else */
+  if (fragmentsToDefine.length > 0) {
+    const fragmentsIncluded = new Set()
+    for (const fragment of fragmentsToDefine) {
+      if (!fragmentsIncluded.has(fragment.name.value)) {
+        query += `\n${print(fragment)}`
+        fragmentsIncluded.add(fragment.name.value)
+      }
+    }
+  }
+
+  return query
 }
 
 module.exports = {

--- a/test/gateway/fix-726.js
+++ b/test/gateway/fix-726.js
@@ -296,4 +296,33 @@ test('federated node should be able to return external Type directly', async (t)
       }
     })
   }
+
+  {
+    const res = await serviceProxy.inject({
+      method: 'POST',
+      url: '/graphql',
+      body: {
+        query: `{
+          meDirect { 
+            id 
+            ...UserFragment
+          }
+        }
+        
+        fragment UserFragment on User {
+          name username
+        }`
+      }
+    })
+
+    t.same(res.json(), {
+      data: {
+        meDirect: {
+          id: '1',
+          name: 'John',
+          username: '@john'
+        }
+      }
+    })
+  }
 })


### PR DESCRIPTION
The federated node was not receiving the `Fragment` declaration from the gateway, so it was triggering an `Unknown fragment` error