### PR TITLE
add missing types for retry services options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -402,7 +402,9 @@ export interface MercuriusGatewayOptions {
   gateway: {
     services: Array<MercuriusGatewayService>;
     pollingInterval?: number;
-    errorHandler?(error: Error, service: MercuriusGatewayService): void
+    errorHandler?(error: Error, service: MercuriusGatewayService): void;
+    retryServicesCount?: number;
+    retryServicesInterval?: number;
   };
 }
 

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -388,6 +388,33 @@ gateway.register(mercurius, {
   }
 })
 
+// Gateway mode with custom services retry props
+gateway.register(mercurius, {
+  gateway: {
+    services: [
+      {
+        name: 'user',
+        url: 'http://localhost:4001/graphql'
+      }
+    ],
+    retryServicesCount: 30,
+    retryServicesInterval: 5000
+  }
+})
+
+expectError(() => gateway.register(mercurius, {
+  gateway: {
+    services: [
+      {
+        name: 'user',
+        url: 'http://localhost:4001/graphql'
+      }
+    ],
+    retryServicesCount: '30',
+    retryServicesInterval: '5000'
+  }
+}))
+
 // Executable schema
 
 const executableSchema = makeExecutableSchema({


### PR DESCRIPTION
Hello! I started looking into using Mercurius as a gateway and I noticed that the typescript interface was missing two fields that were recently added.

This PR adds `retryServicesCount` and `retryServicesInterval` in the MercuriusGatewayOptions interface.