### PR TITLE
Fix #748 Ensure FederatedError `errors` argument is an array.

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -17,6 +17,9 @@ const FEDERATED_ERROR = Symbol('FEDERATED_ERROR')
 // to satisfy the `graphql` error handler
 class FederatedError extends Error {
   constructor (errors) {
+    if (errors && !Array.isArray(errors)) {
+      throw new TypeError('errors must be an Array')
+    }
     super(FEDERATED_ERROR.toString())
     this.extensions = { errors }
   }

--- a/lib/gateway/request.js
+++ b/lib/gateway/request.js
@@ -18,16 +18,18 @@ function agentOption (opts) {
 }
 
 function buildRequest (opts) {
-  let agent
-  if (Array.isArray(opts.url)) {
-    const upstreams = []
-    for (const url of opts.url) {
-      upstreams.push(new URL(url).origin)
-    }
+  let { agent } = opts
+  if (!agent) {
+    if (Array.isArray(opts.url)) {
+      const upstreams = []
+      for (const url of opts.url) {
+        upstreams.push(new URL(url).origin)
+      }
 
-    agent = new BalancedPool(upstreams, agentOption(opts))
-  } else {
-    agent = new Pool(new URL(opts.url).origin, agentOption(opts))
+      agent = new BalancedPool(upstreams, agentOption(opts))
+    } else {
+      agent = new Pool(new URL(opts.url).origin, agentOption(opts))
+    }
   }
 
   const rewriteHeaders = opts.rewriteHeaders || function () { return {} }
@@ -50,7 +52,7 @@ function buildRequest (opts) {
 
       return response
     } catch (err) {
-      throw new FederatedError(err)
+      throw new FederatedError([err])
     }
   }
 
@@ -93,7 +95,7 @@ function sendRequest (request, url, useSecureParse) {
       if (err instanceof FederatedError) {
         throw err
       }
-      throw new FederatedError(err)
+      throw new FederatedError([err])
     }
   }
 }

--- a/test/errors.js
+++ b/test/errors.js
@@ -13,6 +13,21 @@ test('ErrorWithProps - support status code in the constructor', async (t) => {
   t.equal(error.statusCode, 500)
 })
 
+test('FederatedError - throws if given errors is not an array', async (t) => {
+  t.plan(1)
+  t.throws(() => new FederatedError({ message: 'Some error' }))
+})
+
+test('FederatedError - does not throw if given an array', async (t) => {
+  t.plan(1)
+  t.doesNotThrow(() => new FederatedError([{ message: 'Some error' }]))
+})
+
+test('FederatedError - does not throw if not given errors', async (t) => {
+  t.plan(1)
+  t.doesNotThrow(() => new FederatedError())
+})
+
 test('errors - multiple extended errors', async (t) => {
   const schema = `
     type Query {

--- a/test/gateway/errors-in-request.js
+++ b/test/gateway/errors-in-request.js
@@ -1,0 +1,94 @@
+const { test } = require('tap')
+const Fastify = require('fastify')
+const { MockAgent, setGlobalDispatcher } = require('undici')
+const GQL = require('../..')
+
+async function createTestGatewayServer (t, userServiceUrl, agent) {
+  // User service
+  const userServiceSchema = `
+  type Query @extends {
+    me: User
+  }
+
+  type Metadata {
+    info: String!
+  }
+
+  type User @key(fields: "id") {
+    id: ID!
+    name: String!
+    quote(input: String!): String!
+    metadata(input: String!): Metadata!
+  }`
+
+  const gateway = Fastify()
+  t.teardown(async () => {
+    await gateway.close()
+  })
+
+  gateway.register(GQL, {
+    gateway: {
+      services: [{
+        agent,
+        name: 'user',
+        schema: userServiceSchema,
+        url: userServiceUrl
+      }]
+    }
+  })
+
+  return gateway
+}
+
+test('it returns result object with error for exceptions connecting to federated service', async (t) => {
+  t.plan(1)
+  const userServiceHost = 'http://127.0.0.1:3333'
+
+  // Create mock undici agent and pool
+  const mockAgent = new MockAgent()
+  setGlobalDispatcher(mockAgent)
+  const mockPool = mockAgent.get(userServiceHost)
+
+  // Expected error from query request
+  const expectedErrorMessage = 'Request failed.'
+  const expectedResult = {
+    data: {
+      user: null
+    },
+    errors: [{
+      message: expectedErrorMessage
+    }]
+  }
+
+  // Intercept calls to the federated GraphQL service
+  mockPool.intercept({
+    path: '/graphql',
+    method: 'POST'
+  }).replyWithError(new Error(expectedErrorMessage))
+
+  // Create test gateway instance
+  const gateway = await createTestGatewayServer(t, `${userServiceHost}/graphql`, mockPool)
+
+  // GraphQL query to attempt
+  const query = `
+    query {
+      user: me {
+        id
+        name
+      }
+    }`
+
+  // Send the query
+  const result = await gateway.inject({
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    url: '/graphql',
+    body: JSON.stringify({ query })
+  })
+
+  // Clean up gateway instance
+  await gateway.close()
+
+  // Verify query responds correctly with the predefined error
+  t.same(JSON.parse(result.body), expectedResult)
+})


### PR DESCRIPTION
* Add constructor argument validation to `FederatedError` to ensure `errors` is an Array
* Add input validation tests for FederatedError constructor argument
* Fix `request` and `sendRequest` to wrap caught errors in array when creating new `FederatedError`
* Add new test file for `request` to ensure array is used
* Modify existing `sendRequest` test to verify array is used
* Add support for passing in undici agent as part of the federated service configuration. Required for injection during tests. See https://github.com/nodejs/undici/issues/996

Fixes mercurius-js/mercurius#748