### PR TITLE
build: reduce dependabot update frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,13 @@
 version: 2
 updates:
-- package-ecosystem: github-actions
-  directory: "/"
-  ignore:
-    - dependency-name: "actions/*"
-      update-types:
-        ["version-update:semver-minor", "version-update:semver-patch"]
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
- Reduces Dependabot update frequency
- Standardizes YML formatting used to be in line with [GitHub's examples](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates) (double quotes, whitespace etc)
- Removes `ignore` from github actions updates, as discussed with @simoneb in https://github.com/fastify/github-action-merge-dependabot/pull/127 it seems it is longer need it aslong as major tags are used for actions

If happy with this PR then i will go and make the same change to the rest of the Mercurius org repos.