### PR TITLE
Add backport GitHub action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,16 @@
+name: Backport
+on:
+  pull_request:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    runs-on: ubuntu-latest
+    name: Backport
+    steps:
+      - name: Backport
+        uses: tibdex/backport@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,15 @@
+# Developing
+
+## Backporting
+
+The Mercurius repository supports backporting PRs that also need to be applied to older versions.
+
+### How do we do this?
+
+As soon as one opens a PR against the default branch, and the change should be backported to `v8.x`, you should add the corresponding backport label. For example, if we need to backport something to `v8.x`, we add the following label:
+
+- `backport v8.x`
+
+And you are done! If there are no conflicts, the action will open a separate PR with the backport for review.
+
+If the PR can't be automatically backported, the GitHub bot will comment the failure on the PR.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,4 +1,4 @@
-# Developing
+# Development
 
 ## Backporting
 

--- a/docsify/sidebar.md
+++ b/docsify/sidebar.md
@@ -35,4 +35,5 @@
   * [altair-fastify-plugin](/docs/plugins#altair-fastify-plugin)
   * [mercurius-apollo-registry](/docs/plugins#mercurius-apollo-registry)
   * [mercurius-apollo-tracing](/docs/plugins#mercurius-apollo-tracing)
+* [Development](/docs/development)
 * [Faq](/docs/faq)


### PR DESCRIPTION
As titled!

From the updated docs: 

As soon as one opens a PR against the default branch, and the change should be backported to `v8.x`, you should add the corresponding backport label. For example, if we need to backport something to `v8.x`, we add the following label:

- `backport v8.x`

And you are done! If there are no conflicts, the action will open a separate PR with the backport for review.

If the PR can't be automatically backported, the GitHub bot will comment the failure on the PR.
