### PR TITLE
refactor!: replace promise.allsettled dependency with node implementation
BREAKING CHANGE: drop support for node <12.9.0

Refs: #725

### DIFF
--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -19,7 +19,6 @@ const {
 const { MER_ERR_GQL_GATEWAY_REFRESH, MER_ERR_GQL_GATEWAY_INIT, MER_ERR_SERVICE_RETRY_FAILED } = require('./errors')
 const findValueTypes = require('./gateway/find-value-types')
 const getQueryResult = require('./gateway/get-query-result')
-const allSettled = require('promise.allsettled')
 
 function isDefaultType (type) {
   return [
@@ -423,7 +422,7 @@ async function buildGateway (gatewayOpts, app) {
         this._serviceSDLs = serviceSDLs.join('')
       }
 
-      const $refreshResult = await allSettled(
+      const $refreshResult = await Promise.allSettled(
         Object.values(serviceMap).map((service) =>
           service.refresh().catch((err) => {
             // If non-mandatory service or if retry count has exceeded for mandatory service then throw
@@ -482,7 +481,7 @@ async function buildGateway (gatewayOpts, app) {
         }
       }
 
-      await allSettled(
+      await Promise.allSettled(
         Object.values(serviceMap).map((service) =>
           service.reconnectSubscription()
         )

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "graphql-jit": "^0.7.3",
     "mqemitter": "^4.4.1",
     "p-map": "^4.0.0",
-    "promise.allsettled": "^1.0.4",
     "readable-stream": "^3.6.0",
     "safe-stable-stringify": "^2.3.0",
     "secure-json-parse": "^2.4.0",
@@ -74,5 +73,8 @@
   },
   "tsd": {
     "directory": "test/types"
+  },
+  "engines": {
+    "node": ">=12.9.0"
   }
 }


### PR DESCRIPTION
This PR replaces the `promise.allsettled` dependency with the node internal function.
This is only available since node version 12.9.0, so this PR also adds engine constraint for node in package.json.