### PR TITLE
fix: allow cross origin loading for graphiql

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -6,6 +6,7 @@ const importer = {
       const script = document.createElement('script')
       script.type = 'text/javascript'
       script.src = url
+      script.crossOrigin = 'anonymous'
       script.addEventListener('load', () => resolve(script), false)
       script.addEventListener('error', (err) => reject(err), false)
       document.body.appendChild(script)
@@ -45,6 +46,7 @@ function importDependencies () {
   link.type = 'text/css'
   link.rel = 'stylesheet'
   link.media = 'screen,print'
+  link.crossOrigin = 'anonymous'
   document.getElementsByTagName('head')[0].appendChild(link)
 
   return importer.urls([


### PR DESCRIPTION
Fixes https://github.com/mercurius-js/mercurius/issues/771

unpkg is not setting up correct cross origin headers causing browsers to block scripts and styles loaded from them. The proposed change tells the browser to load the content from unpkg.

**How to test the fix**

1. Create a test server ([gist here](https://gist.github.com/conradthegray/16751dd0870376e366d82280b92da265))
2. Run the test server and navigate to `http://localhost:3000/graphiql`
3. You should see a blank page without the fix applied
4. Apply the fix in `mercurius-771/node_modules/mercurius/static/main.js` file
5. Reload the test server and navigate to `http://localhost:3000/graphiql`
6. You should see GraphiQL interface