### PR TITLE
fix: gateway configuration validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,6 +151,25 @@ const plugin = fp(async function (app, opts) {
     throw new MER_ERR_INVALID_OPTS('Adding "schema", "resolvers" or "loaders" to plugin options when plugin is running in gateway mode is not allowed')
   }
 
+  if (gateway && Array.isArray(gateway.services)) {
+    const serviceNames = new Set()
+    for (const service of gateway.services) {
+      if (typeof service !== 'object') {
+        throw new MER_ERR_INVALID_OPTS('gateway: all "services" must be objects')
+      }
+      if (typeof service.name !== 'string') {
+        throw new MER_ERR_INVALID_OPTS('gateway: all "services" must have a "name" String property')
+      }
+      if (serviceNames.has(service.name)) {
+        throw new MER_ERR_INVALID_OPTS(`gateway: all "services" must have a unique "name": "${service.name}" is already used`)
+      }
+      serviceNames.add(service.name)
+      if (typeof service.url !== 'string' && (!Array.isArray(service.url) || service.url.length === 0 || !service.url.every(url => typeof url === 'string'))) {
+        throw new MER_ERR_INVALID_OPTS('gateway: all "services" must have an "url" String, or a non-empty Array of String, property')
+      }
+    }
+  }
+
   if (Array.isArray(schema)) {
     schema = schema.join('\n')
   }

--- a/test/gateway/config.js
+++ b/test/gateway/config.js
@@ -59,3 +59,148 @@ test('"loaders" option not allowed in gateway mode', async (t) => {
     t.equal(err.message, 'Invalid options: Adding "schema", "resolvers" or "loaders" to plugin options when plugin is running in gateway mode is not allowed')
   }
 })
+
+test('Each "gateway" option "services" must be an object', async (t) => {
+  const app = Fastify()
+
+  app.register(GQL, {
+    gateway: {
+      services: [
+        'foo'
+      ]
+    }
+  })
+
+  try {
+    await app.ready()
+  } catch (err) {
+    t.equal(err.message, 'Invalid options: gateway: all "services" must be objects')
+  }
+})
+
+test('Each "gateway" option "services" must have a "name"', async (t) => {
+  const app = Fastify()
+
+  app.register(GQL, {
+    gateway: {
+      services: [
+        {}
+      ]
+    }
+  })
+
+  try {
+    await app.ready()
+  } catch (err) {
+    t.equal(err.message, 'Invalid options: gateway: all "services" must have a "name" String property')
+  }
+})
+
+test('Each "gateway" option "services" must have a "name" that is a String', async (t) => {
+  const app = Fastify()
+
+  app.register(GQL, {
+    gateway: {
+      services: [
+        { name: 42 }
+      ]
+    }
+  })
+
+  try {
+    await app.ready()
+  } catch (err) {
+    t.equal(err.message, 'Invalid options: gateway: all "services" must have a "name" String property')
+  }
+})
+
+test('Each "gateway" option "services" must have a "name" that is unique', async (t) => {
+  const app = Fastify()
+
+  app.register(GQL, {
+    gateway: {
+      services: [
+        { name: 'foo', url: 'https://foo' },
+        { name: 'foo' }
+      ]
+    }
+  })
+
+  try {
+    await app.ready()
+  } catch (err) {
+    t.equal(err.message, 'Invalid options: gateway: all "services" must have a unique "name": "foo" is already used')
+  }
+})
+
+test('Each "gateway" option "services" must have an "url"', async (t) => {
+  const app = Fastify()
+
+  app.register(GQL, {
+    gateway: {
+      services: [
+        { name: 'foo' }
+      ]
+    }
+  })
+
+  try {
+    await app.ready()
+  } catch (err) {
+    t.equal(err.message, 'Invalid options: gateway: all "services" must have an "url" String, or a non-empty Array of String, property')
+  }
+})
+
+test('Each "gateway" option "services" must have an "url" that is a String or an Array', async (t) => {
+  const app = Fastify()
+
+  app.register(GQL, {
+    gateway: {
+      services: [
+        { name: 'foo', url: new URL('https://foo') }
+      ]
+    }
+  })
+
+  try {
+    await app.ready()
+  } catch (err) {
+    t.equal(err.message, 'Invalid options: gateway: all "services" must have an "url" String, or a non-empty Array of String, property')
+  }
+})
+
+test('Each "gateway" option "services" must have an "url" that, if it is an Array, should not be empty', async (t) => {
+  const app = Fastify()
+
+  app.register(GQL, {
+    gateway: {
+      services: [
+        { name: 'foo', url: [] }
+      ]
+    }
+  })
+
+  try {
+    await app.ready()
+  } catch (err) {
+    t.equal(err.message, 'Invalid options: gateway: all "services" must have an "url" String, or a non-empty Array of String, property')
+  }
+})
+
+test('Each "gateway" option "services" must have an "url" that, if it is a non-empty Array, should be filled with Strings only', async (t) => {
+  const app = Fastify()
+
+  app.register(GQL, {
+    gateway: {
+      services: [
+        { name: 'foo', url: [new URL('https://foo')] }
+      ]
+    }
+  })
+
+  try {
+    await app.ready()
+  } catch (err) {
+    t.equal(err.message, 'Invalid options: gateway: all "services" must have an "url" String, or a non-empty Array of String, property')
+  }
+})


### PR DESCRIPTION
Fixes #787 

Checks that the `services` passed to `gateway` option are matching what is documented (in the docs and in TS types) and used so far:
1. `services` should have a unique (String) `name` 
2. `services` should have one or multiple (as an Array) `url` that is of type `String`

Given the current `gateway` `services` option is really permissive and this PR restricts it, this may be considered as a BREAKING CHANGE, but given TS types explicitly restrains the options to what is implemented by this PR, we might want not to consider it breaking... WDYT ?