### PR TITLE
fix: check null lruGatewayResolvers when cache option is disabled 

### DIFF
--- a/lib/gateway/make-resolver.js
+++ b/lib/gateway/make-resolver.js
@@ -404,7 +404,7 @@ function makeResolver ({ service, createOperation, transformData, isQuery, isRef
     const resolverKey = `${queryId.replace(/\d/g, '_IDX_')}.${type.toString()}`
     const { reply, __currentQuery, lruGatewayResolvers, pubsub } = context
 
-    const cached = lruGatewayResolvers.get(`${__currentQuery}_${resolverKey}`)
+    const cached = lruGatewayResolvers != null && lruGatewayResolvers.get(`${__currentQuery}_${resolverKey}`)
     let variableNamesToDefine
     let operation
     let query
@@ -442,7 +442,10 @@ function makeResolver ({ service, createOperation, transformData, isQuery, isRef
       const usedFragments = getFragmentNamesInSelection(selections)
       const fragmentsToDefine = collectFragmentsToInclude(usedFragments, fragments, service, schema)
       query = appendFragments(query, fragmentsToDefine)
-      lruGatewayResolvers.set(`${__currentQuery}_${resolverKey}`, { query, operation, variableNamesToDefine })
+
+      if (lruGatewayResolvers != null) {
+        lruGatewayResolvers.set(`${__currentQuery}_${resolverKey}`, { query, operation, variableNamesToDefine })
+      }
     }
 
     const variables = {}


### PR DESCRIPTION
since we cannot pass function in validationRules options because it's incompatible with query caching [#L73](https://github.com/mercurius-js/mercurius/blob/117662dad9f0d7977acfdb04d88d349d8e87f8e0/index.js#L73), so I set the cache option to false, but I got an error like this `Cannot read properties of null (reading 'get')` 

when I check the code there is no null check in this line [#L407](https://github.com/mercurius-js/mercurius/blob/117662dad9f0d7977acfdb04d88d349d8e87f8e0/lib/gateway/make-resolver.js#L407), 

so I proposed this MR to fix the issue above, please kindly check this TIA 🙏 