### PR TITLE
Fix LRU require for module bundlers

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const fp = require('fastify-plugin')
-const LRU = require('tiny-lru')
+let LRU = require("tiny-lru");
 const routes = require('./lib/routes')
 const { compileQuery, isCompiledQuery } = require('graphql-jit')
 const { Factory } = require('single-user-cache')
@@ -43,6 +43,9 @@ const {
 const { Hooks, assignLifeCycleHooksToContext, assignApplicationLifecycleHooksToContext } = require('./lib/hooks')
 const { kLoaders, kFactory, kSubscriptionFactory, kHooks } = require('./lib/symbols')
 const { preParsingHandler, preValidationHandler, preExecutionHandler, onResolutionHandler, onGatewayReplaceSchemaHandler } = require('./lib/handlers')
+
+// Required for module bundlers
+LRU = typeof LRU === 'function' ? LRU : LRU.default
 
 function buildCache (opts) {
   if (Object.prototype.hasOwnProperty.call(opts, 'cache')) {

--- a/lib/persistedQueryDefaults.js
+++ b/lib/persistedQueryDefaults.js
@@ -1,7 +1,10 @@
 'use strict'
 
 const crypto = require('crypto')
-const LRU = require('tiny-lru')
+let LRU = require("tiny-lru")
+
+// Required for module bundlers
+LRU = typeof LRU === "function" ? LRU : LRU.default
 
 const persistedQueryDefaults = {
   prepared: (persistedQueries) => ({


### PR DESCRIPTION
When using Mercurius with a module bundler such as esbuild or webpack, running will output `TypeError: LRU is not a function`.

Not sure what originates the error, but it has already been fixed in fastify (see https://github.com/fastify/fastify/pull/2918).