### PR TITLE
Throw GraphQL Schema error when federated schemas are not extend each other properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const fp = require('fastify-plugin')
-let LRU = require("tiny-lru");
+let LRU = require('tiny-lru')
 const routes = require('./lib/routes')
 const { compileQuery, isCompiledQuery } = require('graphql-jit')
 const { Factory } = require('single-user-cache')

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -4,7 +4,8 @@ const {
   getNamedType,
   isObjectType,
   isScalarType,
-  Kind
+  Kind,
+  GraphQLError
 } = require('graphql')
 const { Factory } = require('single-user-cache')
 const buildFederatedSchema = require('./federation')
@@ -16,7 +17,7 @@ const {
   createEntityReferenceResolverOperation,
   kEntityResolvers
 } = require('./gateway/make-resolver')
-const { MER_ERR_GQL_GATEWAY_REFRESH, MER_ERR_GQL_GATEWAY_INIT, MER_ERR_SERVICE_RETRY_FAILED } = require('./errors')
+const { MER_ERR_GQL_GATEWAY_REFRESH, MER_ERR_GQL_GATEWAY_INIT, MER_ERR_SERVICE_RETRY_FAILED, MER_ERR_GQL_INVALID_SCHEMA } = require('./errors')
 const findValueTypes = require('./gateway/find-value-types')
 const getQueryResult = require('./gateway/get-query-result')
 
@@ -285,6 +286,93 @@ function defineResolvers (schema, typeToServiceMap, serviceMap, typeFieldsToServ
   }
 }
 
+function checkForConflictingSchemas (serviceMap, valueTypes) {
+  const existingTypes = new Map()
+  const errors = []
+
+  Object.entries(serviceMap).forEach(([_, value]) => {
+    const types = value.schema.getTypeMap()
+    for (const type of Object.values(types)) {
+      if (valueTypes.includes(type.name)) {
+        continue
+      }
+
+      const check = isObjectType(type) && !isDefaultType(type.name) && type.name !== '_Service'
+      if (!check) {
+        continue
+      }
+
+      const isExtension = type.extensionASTNodes.length && type.extensionASTNodes[0].name.value === type.name
+
+      const doesNotExistIsExtension = !existingTypes.has(type.name) && isExtension
+      const doesNotExistIsNotExtension = !existingTypes.has(type.name) && !isExtension
+      const existsAndIsNotExtension = existingTypes.has(type.name) && !isExtension
+      const existsAndHasExtension = existingTypes.has(type.name) && isExtension
+
+      if (doesNotExistIsExtension || existsAndHasExtension) {
+        continue
+      } else if (existsAndIsNotExtension) {
+        const firstType = existingTypes.get(type.name, type)
+
+        const firstTypeFields = firstType.getFields()
+        const firstTypeFieldNames = Object.keys(firstTypeFields)
+
+        const fields = type.getFields()
+        const fieldNames = Object.keys(fields)
+
+        // Here we want to ensure that the types
+        // are the same
+        let identical = true
+
+        if (fieldNames.length !== firstTypeFieldNames.length) {
+          identical = false
+        } else {
+          for (let i = 0; i < fieldNames.length; i++) {
+            const fieldName = fieldNames[i]
+            const currentField = fields[fieldName]
+            const firstTypeField = firstTypeFields[fieldName]
+
+            const currentFieldType = currentField.astNode.type.type.name.value
+            const firstTypeFieldType = firstTypeField.astNode.type.type.name.value
+            // Ensure they are the same type
+            if (currentFieldType !== firstTypeFieldType) {
+              identical = false
+              break
+            }
+
+            // Ensure they are both same nullability
+            if (currentField.astNode.type.kind !== firstTypeField.astNode.type.kind) {
+              identical = false
+              break
+            }
+          }
+        }
+
+        if (!identical) {
+          const error = new Error(`Type ${type.name} may only be defined once in the schema`)
+          const gqlError = new GraphQLError(
+            error.message,
+            error.nodes,
+            error.source,
+            error.positions,
+            error.path,
+            error.originalError,
+            error.extensions
+          )
+          gqlError.locations = error.locations
+          gqlError.name = error.name
+
+          errors.push(error)
+        }
+      } else if (doesNotExistIsNotExtension) {
+        existingTypes.set(type.name, type)
+      }
+    }
+  })
+
+  return errors
+}
+
 function defaultErrorHandler (error, service) {
   if (service.mandatory) {
     throw error
@@ -407,6 +495,14 @@ async function buildGateway (gatewayOpts, app) {
   const valueTypes = findValueTypes(allTypes)
   for (const typeName of valueTypes) {
     typeToServiceMap[typeName] = null
+  }
+
+  const conflictErrors = checkForConflictingSchemas(serviceMap, valueTypes)
+
+  if (conflictErrors.length > 0) {
+    const err = new MER_ERR_GQL_INVALID_SCHEMA()
+    err.errors = conflictErrors
+    throw err
   }
 
   defineResolvers(schema, typeToServiceMap, serviceMap, typeFieldsToService)

--- a/lib/persistedQueryDefaults.js
+++ b/lib/persistedQueryDefaults.js
@@ -1,10 +1,10 @@
 'use strict'
 
 const crypto = require('crypto')
-let LRU = require("tiny-lru")
+let LRU = require('tiny-lru')
 
 // Required for module bundlers
-LRU = typeof LRU === "function" ? LRU : LRU.default
+LRU = typeof LRU === 'function' ? LRU : LRU.default
 
 const persistedQueryDefaults = {
   prepared: (persistedQueries) => ({

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint:standard": "standard | snazzy",
     "lint:typescript": "standard --parser @typescript-eslint/parser --plugin @typescript-eslint/eslint-plugin test/types/*.ts",
     "typescript": "tsd",
-    "test": "npm run lint && npm run unit && npm run typescript"
+    "test": "npm run lint && npm run unit && npm run typescript",
+    "test:one": "tap test/gateway/value-types.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Aims to resolve #826 

This is currently an experimental draft PR as I get an understanding of what the desired behaviours are for merging federated schema types. The overall idea is that if a schema comes together and non value types do not correctly extend each other within that, then it should throw a GraphQL schema validation error.

I'm pretty certain the current code doesn't do exhaustive checks on ensuring entity types are identical when they haven't been extended - but hopefully at least it gives some ideas on how that might work. I know in another part of the code base for value types there is also a TODO: for ensuring equality between value types.

One other aspect I am not totally sure on is if the order of extension matters, for example if the schema extends a type before it has been defined, but it is defined later in the schema.