### PR TITLE
Always teardown subscriptions on completion

### DIFF
--- a/lib/subscription-connection.js
+++ b/lib/subscription-connection.js
@@ -284,7 +284,7 @@ module.exports = class SubscriptionConnection {
     this.sendMessage(this.protocolMessageTypes.GQL_DATA, id, response)
     this.sendMessage(this.protocolMessageTypes.GQL_COMPLETE, id, null)
   }
-  
+
   handleGQLComplete (id) {
     const sc = this.subscriptionContexts.get(id)
     if (sc) {
@@ -307,7 +307,7 @@ module.exports = class SubscriptionConnection {
         return this.handleConnectionClose()
       }
     }
-    
+
     this.handleGQLComplete(data.id)
   }
 

--- a/lib/subscription-connection.js
+++ b/lib/subscription-connection.js
@@ -271,6 +271,7 @@ module.exports = class SubscriptionConnection {
     }
 
     this.sendMessage(this.protocolMessageTypes.GQL_COMPLETE, id, null)
+    this.handleGQLComplete(id)
   }
 
   async _executeQueryOrMutation ({ query, context, variables, operationName, id }) {
@@ -283,6 +284,19 @@ module.exports = class SubscriptionConnection {
     this.sendMessage(this.protocolMessageTypes.GQL_DATA, id, response)
     this.sendMessage(this.protocolMessageTypes.GQL_COMPLETE, id, null)
   }
+  
+  handleGQLComplete (id) {
+    const sc = this.subscriptionContexts.get(id)
+    if (sc) {
+      sc.close && sc.close()
+      this.subscriptionContexts.delete(id)
+    }
+    const subIter = this.subscriptionIters.get(id)
+    if (subIter) {
+      subIter.return && subIter.return()
+      this.subscriptionIters.delete(id)
+    }
+  }
 
   async handleGQLStop (data) {
     if (this.context.onSubscriptionEnd) {
@@ -293,16 +307,8 @@ module.exports = class SubscriptionConnection {
         return this.handleConnectionClose()
       }
     }
-    const sc = this.subscriptionContexts.get(data.id)
-    if (sc) {
-      sc.close && sc.close()
-      this.subscriptionContexts.delete(data.id)
-    }
-    const subIter = this.subscriptionIters.get(data.id)
-    if (subIter) {
-      subIter.return && subIter.return()
-      this.subscriptionIters.delete(data.id)
-    }
+    
+    this.handleGQLComplete(data.id)
   }
 
   handleConnectionClose () {


### PR DESCRIPTION
Always clear `SubscriptionConnection.subscriptionContexts` and `SubscriptionConnection.subscriptionIters` after a subscription completes, instead of waiting for the client to send a `complete` message.

This prevents buggy clients from leaking memory on the server.