### PR TITLE
feat: uniquely identify batched queries

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,6 +25,9 @@ export interface PubSub {
 export interface MercuriusContext {
   app: FastifyInstance;
   reply: FastifyReply;
+  operationsCount?: Number;
+  operationId?: Number;
+  __currentQuery: String;
   /**
    * __Caution__: Only available if `subscriptions` are enabled
    */

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,9 +25,9 @@ export interface PubSub {
 export interface MercuriusContext {
   app: FastifyInstance;
   reply: FastifyReply;
-  operationsCount?: Number;
-  operationId?: Number;
-  __currentQuery: String;
+  operationsCount?: number;
+  operationId?: number;
+  __currentQuery: string;
   /**
    * __Caution__: Only available if `subscriptions` are enabled
    */

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -220,16 +220,11 @@ module.exports = async function (app, opts) {
       return new MER_ERR_GQL_PERSISTED_QUERY_NOT_FOUND('Unknown query')
     }
 
-    // Create individual contexts for multiple operations, otherwise reference the original context
-    const context = request[kRequestContext].operationsCount > 1
-      ? Object.create(request[kRequestContext])
-      : request[kRequestContext]
-
     // Handle the query, throwing an error if required
     return reply.graphql(
       query,
       Object.assign(
-        context,
+        request[kRequestContext],
         { pubsub: subscriber, __currentQuery: query }
       ),
       variables,
@@ -357,13 +352,18 @@ module.exports = async function (app, opts) {
 
     if (allowBatchedQueries && Array.isArray(request.body)) {
       // Batched query
-      Object.assign(request[kRequestContext], { operationsCount: request.body.length })
+      const operationsCount = request.body.length
+
+      Object.assign(request[kRequestContext], { operationsCount })
 
       return Promise.all(request.body.map(async (r, operationId) => {
-        Object.assign(request[kRequestContext], { operationId })
+        // Create individual reqs for multiple operations, otherwise reference the original req
+        const operationReq = operationsCount > 1 ? Object.create(request) : request
+
+        Object.assign(operationReq[kRequestContext], { operationId })
 
         try {
-          return await execute(r, request, reply)
+          return await execute(r, operationReq, reply)
         } catch (e) {
           const { response } = errorFormatter(e, request[kRequestContext])
           return response

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -220,11 +220,16 @@ module.exports = async function (app, opts) {
       return new MER_ERR_GQL_PERSISTED_QUERY_NOT_FOUND('Unknown query')
     }
 
+    // Create individual contexts for multiple operations, otherwise reference the original context
+    const context = request[kRequestContext].operationsCount > 1
+      ? Object.create(request[kRequestContext])
+      : request[kRequestContext]
+
     // Handle the query, throwing an error if required
     return reply.graphql(
       query,
       Object.assign(
-        request[kRequestContext],
+        context,
         { pubsub: subscriber, __currentQuery: query }
       ),
       variables,
@@ -352,13 +357,18 @@ module.exports = async function (app, opts) {
 
     if (allowBatchedQueries && Array.isArray(request.body)) {
       // Batched query
-      return Promise.all(request.body.map(r =>
-        execute(r, request, reply)
-          .catch(e => {
-            const { response } = errorFormatter(e, request[kRequestContext])
-            return response
-          })
-      ))
+      Object.assign(request[kRequestContext], { operationsCount: request.body.length })
+
+      return Promise.all(request.body.map(async (r, operationId) => {
+        Object.assign(request[kRequestContext], { operationId })
+
+        try {
+          return await execute(r, request, reply)
+        } catch (e) {
+          const { response } = errorFormatter(e, request[kRequestContext])
+          return response
+        }
+      }))
     } else {
       // Regular query
       return execute(request.body, request, reply)

--- a/test/batched.js
+++ b/test/batched.js
@@ -384,7 +384,7 @@ test('POST batched query has an individual context for each operation', async (t
     ]
   })
 
-  t.ok(contextSpy.calledTwice)
-  t.ok(contextSpy.calledWith(0, 2, sinon.match(/TestQuery/)))
-  t.ok(contextSpy.calledWith(1, 2, sinon.match(/DoubleQuery/)))
+  sinon.assert.calledTwice(contextSpy)
+  sinon.assert.calledWith(contextSpy, 0, 2, sinon.match(/TestQuery/))
+  sinon.assert.calledWith(contextSpy, 1, 2, sinon.match(/DoubleQuery/))
 })

--- a/test/options.js
+++ b/test/options.js
@@ -30,8 +30,6 @@ const resolvers = {
 }
 
 test('call compileQuery with correct options if compilerOptions specified', async t => {
-  t.plan(1)
-
   const app = Fastify()
   t.teardown(() => app.close())
 
@@ -82,5 +80,5 @@ test('call compileQuery with correct options if compilerOptions specified', asyn
     body: JSON.stringify({ query })
   })
 
-  t.ok(compileQueryStub.calledOnceWith(sinon.match.any, sinon.match.any, sinon.match.any, { customJSONSerializer: true }))
+  sinon.assert.calledOnceWithExactly(compileQueryStub, sinon.match.any, sinon.match.any, sinon.match.any, { customJSONSerializer: true })
 })

--- a/test/subscription-connection.js
+++ b/test/subscription-connection.js
@@ -574,24 +574,17 @@ test('subscription connection handles query when fullWsTransport: true', async (
     })
   )
 
-  t.ok(
-    send.withArgs(
-      JSON.stringify({
-        type: 'next',
-        id: 1,
-        payload: {}
-      })
-    ).calledOnce
-  )
-  t.ok(
-    send.withArgs(
-      JSON.stringify({
-        type: 'complete',
-        id: 1,
-        payload: null
-      })
-    ).calledOnce
-  )
+  sinon.assert.calledTwice(send)
+  sinon.assert.calledWith(send, JSON.stringify({
+    type: 'next',
+    id: 1,
+    payload: {}
+  }))
+  sinon.assert.calledWith(send, JSON.stringify({
+    type: 'complete',
+    id: 1,
+    payload: null
+  }))
 })
 
 test('subscription connection handles mutation when fullWsTransport: true', async (t) => {
@@ -625,24 +618,17 @@ test('subscription connection handles mutation when fullWsTransport: true', asyn
     })
   )
 
-  t.ok(
-    send.withArgs(
-      JSON.stringify({
-        type: 'next',
-        id: 1,
-        payload: {}
-      })
-    ).calledOnce
-  )
-  t.ok(
-    send.withArgs(
-      JSON.stringify({
-        type: 'complete',
-        id: 1,
-        payload: null
-      })
-    ).calledOnce
-  )
+  sinon.assert.calledTwice(send)
+  sinon.assert.calledWith(send, JSON.stringify({
+    type: 'next',
+    id: 1,
+    payload: {}
+  }))
+  sinon.assert.calledWith(send, JSON.stringify({
+    type: 'complete',
+    id: 1,
+    payload: null
+  }))
 })
 
 test('subscription data is released right after it ends', async (t) => {

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -1,4 +1,4 @@
-import { expectAssignable, expectError } from 'tsd'
+import { expectAssignable, expectError, expectType } from 'tsd'
 /* eslint-disable no-unused-expressions */
 import { EventEmitter } from 'events'
 // eslint-disable-next-line no-unused-vars
@@ -779,4 +779,11 @@ expectError(() => {
 
 expectError(() => {
   return mercurius.defaultErrorFormatter({}, undefined)
+})
+
+// Context contains correct information about (batched) query identity
+app.graphql.addHook('onResolution', async function (_execution, context) {
+  expectType<number | undefined>(context.operationId)
+  expectType<number | undefined>(context.operationsCount)
+  expectType<string>(context.__currentQuery)
 })


### PR DESCRIPTION
resolves #842

Fixes `context.__currentQuery` being overwritten by subsequent batched query operations.
Stores `context.operationsCount` and `context.operationId` (same naming as with subscriptions) to uniquely identify batched query operations at a later stage.