### PR TITLE
fix: handle flaky tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@graphql-tools/merge": "^8.0.0",
     "@graphql-tools/schema": "^8.0.0",
     "@graphql-tools/utils": "^8.0.0",
-    "@sinonjs/fake-timers": "^9.0.0",
+    "@sinonjs/fake-timers": "^9.1.2",
     "@types/node": "^18.0.0",
     "@types/ws": "^8.2.0",
     "@types/isomorphic-form-data": "^2.0.0",
@@ -48,7 +48,7 @@
     "snazzy": "^9.0.0",
     "split2": "^4.0.0",
     "standard": "^17.0.0",
-    "tap": "^16.0.0",
+    "tap": "^16.3.0",
     "tsd": "^0.22.0",
     "typescript": "^4.3.5",
     "wait-on": "^6.0.0"

--- a/test/gateway/retry-failed-services.js
+++ b/test/gateway/retry-failed-services.js
@@ -119,11 +119,11 @@ test('gateway - retry mandatory failed services on startup', async (t) => {
     advanceTimeDelta: 100
   })
 
-  const service1 = await createTestService(5001, userService.schema, userService.resolvers)
+  const service1 = await createTestService(0, userService.schema, userService.resolvers)
 
   let service2 = null
   setTimeout(async () => {
-    service2 = await createTestService(5002, postService.schema, postService.resolvers)
+    service2 = await createTestService(5113, postService.schema, postService.resolvers)
   }, 5000)
 
   const app = Fastify()
@@ -140,12 +140,12 @@ test('gateway - retry mandatory failed services on startup', async (t) => {
       services: [
         {
           name: 'user',
-          url: 'http://localhost:5001/graphql',
+          url: `http://localhost:${service1.server.address().port}/graphql`,
           mandatory: false
         },
         {
           name: 'post',
-          url: 'http://localhost:5002/graphql',
+          url: 'http://localhost:5113/graphql',
           mandatory: true
         }
       ]
@@ -221,11 +221,11 @@ test('gateway - should not call onGatewayReplaceSchemaHandler if the hook is not
     advanceTimeDelta: 100
   })
 
-  const service1 = await createTestService(5001, userService.schema, userService.resolvers)
+  const service1 = await createTestService(0, userService.schema, userService.resolvers)
 
   let service2 = null
   setTimeout(async () => {
-    service2 = await createTestService(5002, postService.schema, postService.resolvers)
+    service2 = await createTestService(5111, postService.schema, postService.resolvers)
   }, 5000)
 
   const app = Fastify()
@@ -242,12 +242,12 @@ test('gateway - should not call onGatewayReplaceSchemaHandler if the hook is not
       services: [
         {
           name: 'user',
-          url: 'http://localhost:5001/graphql',
+          url: `http://localhost:${service1.server.address().port}/graphql`,
           mandatory: false
         },
         {
           name: 'post',
-          url: 'http://localhost:5002/graphql',
+          url: 'http://localhost:5111/graphql',
           mandatory: true
         }
       ],
@@ -319,7 +319,7 @@ test('gateway - dont retry non-mandatory failed services on startup', async (t) 
     advanceTimeDelta: 100
   })
 
-  const service1 = await createTestService(5001, userService.schema, userService.resolvers)
+  const service1 = await createTestService(0, userService.schema, userService.resolvers)
 
   const app = Fastify()
   t.teardown(async () => {
@@ -334,12 +334,12 @@ test('gateway - dont retry non-mandatory failed services on startup', async (t) 
       services: [
         {
           name: 'user',
-          url: 'http://localhost:5001/graphql',
+          url: `http://localhost:${service1.server.address().port}/graphql`,
           mandatory: false
         },
         {
           name: 'post',
-          url: 'http://localhost:5002/graphql',
+          url: 'http://localhost:5112/graphql',
           mandatory: false
         }
       ],
@@ -406,11 +406,11 @@ test('gateway - should log error if retry throws', async (t) => {
     advanceTimeDelta: 100
   })
 
-  const service1 = await createTestService(5001, userService.schema, userService.resolvers)
+  const service1 = await createTestService(0, userService.schema, userService.resolvers)
 
   let service2 = null
   setTimeout(async () => {
-    service2 = await createTestService(5002, postService.schema, postService.resolvers)
+    service2 = await createTestService(5113, postService.schema, postService.resolvers)
   }, 2000)
 
   const app = Fastify()
@@ -436,12 +436,12 @@ test('gateway - should log error if retry throws', async (t) => {
       services: [
         {
           name: 'user',
-          url: 'http://localhost:5001/graphql',
+          url: `http://localhost:${service1.server.address().port}/graphql`,
           mandatory: false
         },
         {
           name: 'post',
-          url: 'http://localhost:5002/graphql',
+          url: 'http://localhost:5113/graphql',
           mandatory: true
         }
       ],
@@ -456,8 +456,8 @@ test('gateway - should log error if retry throws', async (t) => {
 
   await app.ready()
 
-  for (let i = 0; i < 10; i++) {
-    await clock.tickAsync(1000)
+  for (let i = 0; i < 100; i++) {
+    await clock.tickAsync(100)
   }
 })
 
@@ -497,7 +497,7 @@ test('gateway - stop retrying after no. of retries exceeded', async (t) => {
         },
         {
           name: 'post',
-          url: 'http://localhost:5002/graphql',
+          url: 'http://localhost:5114/graphql',
           mandatory: true
         }
       ],


### PR DESCRIPTION
I still believe fake-timers are the main issue behind this. There are still some other tests being flaky due to fake timers tickAsync. I opened a pull request to discuss a potential solution.

Steps I've taken:

- Understand multiple tests were contradicting each other due to the same port number
- Run the test couple of times, it was still flaky
- Updated sinon fake timers and tap, since the only ambigious side of the test was the fake timers.
- Found the following issue: https://github.com/tapjs/node-tap/issues/709
- Changed for loop 10 times tickAsync(1000) with for loop 100 times with tickAsync(100). Which solved the issue on the retry-failed-services.js test.