### PR TITLE
feat: update to GraphiQL to version 2.0.2

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -42,7 +42,7 @@ function render () {
 
 function importDependencies () {
   const link = document.createElement('link')
-  link.href = 'https://unpkg.com/graphiql@1.4.2/graphiql.css'
+  link.href = 'https://unpkg.com/graphiql@2.0.2/graphiql.min.css'
   link.type = 'text/css'
   link.rel = 'stylesheet'
   link.media = 'screen,print'
@@ -50,10 +50,9 @@ function importDependencies () {
   document.getElementsByTagName('head')[0].appendChild(link)
 
   return importer.urls([
-    'https://unpkg.com/react@16.8.0/umd/react.production.min.js',
-    'https://unpkg.com/react-dom@16.8.0/umd/react-dom.production.min.js',
-    'https://unpkg.com/graphiql@1.4.2/graphiql.min.js',
-    'https://unpkg.com/subscriptions-transport-ws@0.9.19/browser/client.js'
+    'https://unpkg.com/react@18.2.0/umd/react.production.min.js',
+    'https://unpkg.com/react-dom@18.2.0/umd/react-dom.production.min.js',
+    'https://unpkg.com/graphiql@2.0.2/graphiql.min.js'
   ])
 }
 

--- a/static/sw.js
+++ b/static/sw.js
@@ -2,14 +2,13 @@
 
 self.addEventListener('install', function (e) {
   e.waitUntil(
-    caches.open('graphiql-v1.4.0').then(function (cache) {
+    caches.open('graphiql-v2.0.2').then(function (cache) {
       return cache.addAll([
         './main.js',
-        'https://unpkg.com/graphiql@1.4.2/graphiql.css',
-        'https://unpkg.com/react@16.8.0/umd/react.production.min.js',
-        'https://unpkg.com/react-dom@16.8.0/umd/react-dom.production.min.js',
-        'https://unpkg.com/graphiql@1.4.2/graphiql.min.js',
-        'https://unpkg.com/subscriptions-transport-ws@0.9.19/browser/client.js'
+        'https://unpkg.com/graphiql@2.0.2/graphiql.css',
+        'https://unpkg.com/react@18.2.0/umd/react.production.min.js',
+        'https://unpkg.com/react-dom@18.2.0/umd/react-dom.production.min.js',
+        'https://unpkg.com/graphiql@2.0.2/graphiql.min.js'
       ])
     })
   )


### PR DESCRIPTION
The graphiql version used by Mercurius was pretty old. Version 2 recently came out which has a lot of improvements.

I have verified this in my own project and it appears to work properly.

<img width="1134" alt="Screenshot 2022-08-28 at 15 25 49" src="https://user-images.githubusercontent.com/697707/187074077-74a744b2-2a31-4f7b-a73f-755a9b9ac812.png">
