### PR TITLE
fix: clear native timers on tests

### DIFF
--- a/test/gateway/application-hooks.js
+++ b/test/gateway/application-hooks.js
@@ -19,9 +19,8 @@ test('onGatewayReplaceSchema - polling interval with a new schema should trigger
   const clock = FakeTimers.install({
     shouldClearNativeTimers: true,
     shouldAdvanceTime: true,
-    advanceTimeDelta: 40
+    advanceTimeDelta: 100
   })
-  t.teardown(() => clock.uninstall())
 
   const resolvers = {
     Query: {
@@ -43,6 +42,7 @@ test('onGatewayReplaceSchema - polling interval with a new schema should trigger
   t.teardown(async () => {
     await gateway.close()
     await userService.close()
+    clock.uninstall()
   })
 
   userService.register(GQL, {
@@ -112,9 +112,8 @@ test('onGatewayReplaceSchema - should log an error should any errors occur in th
   const clock = FakeTimers.install({
     shouldClearNativeTimers: true,
     shouldAdvanceTime: true,
-    advanceTimeDelta: 40
+    advanceTimeDelta: 100
   })
-  t.teardown(() => clock.uninstall())
 
   const resolvers = {
     Query: {
@@ -136,6 +135,7 @@ test('onGatewayReplaceSchema - should log an error should any errors occur in th
   t.teardown(async () => {
     await gateway.close()
     await userService.close()
+    clock.uninstall()
   })
 
   userService.register(GQL, {

--- a/test/gateway/application-hooks.js
+++ b/test/gateway/application-hooks.js
@@ -17,6 +17,7 @@ test('onGatewayReplaceSchema - polling interval with a new schema should trigger
   t.plan(2)
 
   const clock = FakeTimers.install({
+    shouldClearNativeTimers: true,
     shouldAdvanceTime: true,
     advanceTimeDelta: 40
   })
@@ -95,7 +96,9 @@ test('onGatewayReplaceSchema - polling interval with a new schema should trigger
   )
   userService.graphql.defineResolvers(resolvers)
 
-  await clock.tickAsync(2000)
+  for (let i = 0; i < 10; i++) {
+    await clock.tickAsync(200)
+  }
 
   // We need the event loop to actually spin twice to
   // be able to propagate the change
@@ -107,6 +110,7 @@ test('onGatewayReplaceSchema - should log an error should any errors occur in th
   t.plan(2)
 
   const clock = FakeTimers.install({
+    shouldClearNativeTimers: true,
     shouldAdvanceTime: true,
     advanceTimeDelta: 40
   })
@@ -194,7 +198,9 @@ test('onGatewayReplaceSchema - should log an error should any errors occur in th
   )
   userService.graphql.defineResolvers(resolvers)
 
-  await clock.tickAsync(2000)
+  for (let i = 0; i < 10; i++) {
+    await clock.tickAsync(200)
+  }
 
   // We need the event loop to actually spin twice to
   // be able to propagate the change

--- a/test/gateway/pollingInterval.js
+++ b/test/gateway/pollingInterval.js
@@ -15,6 +15,7 @@ const GQL = require('../..')
 
 test('Polling schemas with disable cache', async (t) => {
   const clock = FakeTimers.install({
+    shouldClearNativeTimers: true,
     shouldAdvanceTime: true,
     advanceTimeDelta: 40
   })
@@ -104,6 +105,7 @@ test('Polling schemas with disable cache', async (t) => {
 
 test('Polling schemas', async (t) => {
   const clock = FakeTimers.install({
+    shouldClearNativeTimers: true,
     shouldAdvanceTime: true,
     advanceTimeDelta: 40
   })
@@ -337,6 +339,7 @@ test('Polling schemas (gateway.polling interval is not a number)', async (t) => 
 
 test("Polling schemas (if service is down, schema shouldn't be changed)", async (t) => {
   const clock = FakeTimers.install({
+    shouldClearNativeTimers: true,
     shouldAdvanceTime: true,
     advanceTimeDelta: 40
   })
@@ -623,6 +626,7 @@ test('Polling schemas (if service is mandatory, exception should be thrown)', as
 
 test('Polling schemas (cache should be cleared)', async (t) => {
   const clock = FakeTimers.install({
+    shouldClearNativeTimers: true,
     shouldAdvanceTime: true,
     advanceTimeDelta: 40
   })
@@ -794,6 +798,7 @@ test('Polling schemas (cache should be cleared)', async (t) => {
 
 test('Polling schemas (should properly regenerate the schema when a downstream service restarts)', async (t) => {
   const clock = FakeTimers.install({
+    shouldClearNativeTimers: true,
     shouldAdvanceTime: true,
     advanceTimeDelta: 40
   })
@@ -916,7 +921,9 @@ test('Polling schemas (should properly regenerate the schema when a downstream s
 
   await restartedUserService.listen({ port: userServicePort })
 
-  await clock.tickAsync(10000)
+  for (let i = 0; i < 100; i++) {
+    await clock.tickAsync(100)
+  }
 
   // We need the event loop to actually spin twice to
   // be able to propagate the change
@@ -983,6 +990,7 @@ test('Polling schemas (subscriptions should be handled)', async (t) => {
   t.plan(12)
 
   const clock = FakeTimers.install({
+    shouldClearNativeTimers: true,
     shouldAdvanceTime: true,
     advanceTimeDelta: 40
   })

--- a/test/gateway/pollingInterval.js
+++ b/test/gateway/pollingInterval.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('tap')
+const { test, t } = require('tap')
 
 const FakeTimers = require('@sinonjs/fake-timers')
 
@@ -13,13 +13,19 @@ const WebSocket = require('ws')
 const buildFederationSchema = require('../../lib/federation')
 const GQL = require('../..')
 
-test('Polling schemas with disable cache', async (t) => {
-  const clock = FakeTimers.install({
+t.beforeEach(({ context }) => {
+  context.clock = FakeTimers.install({
     shouldClearNativeTimers: true,
     shouldAdvanceTime: true,
     advanceTimeDelta: 40
   })
+})
 
+t.afterEach(({ context }) => {
+  context.clock.uninstall()
+})
+
+test('Polling schemas with disable cache', async (t) => {
   const resolvers = {
     Query: {
       me: (root, args, context, info) => user
@@ -40,7 +46,6 @@ test('Polling schemas with disable cache', async (t) => {
   t.teardown(async () => {
     await gateway.close()
     await userService.close()
-    clock.uninstall()
   })
 
   userService.register(GQL, {
@@ -104,12 +109,6 @@ test('Polling schemas with disable cache', async (t) => {
 })
 
 test('Polling schemas', async (t) => {
-  const clock = FakeTimers.install({
-    shouldClearNativeTimers: true,
-    shouldAdvanceTime: true,
-    advanceTimeDelta: 40
-  })
-
   const resolvers = {
     Query: {
       me: (root, args, context, info) => user
@@ -130,7 +129,6 @@ test('Polling schemas', async (t) => {
   t.teardown(async () => {
     await gateway.close()
     await userService.close()
-    clock.uninstall()
   })
 
   userService.register(GQL, {
@@ -237,7 +235,7 @@ test('Polling schemas', async (t) => {
   userService.graphql.defineResolvers(resolvers)
 
   for (let i = 0; i < 10; i++) {
-    await clock.tickAsync(200)
+    await t.context.clock.tickAsync(200)
   }
 
   // We need the event loop to actually spin twice to
@@ -340,12 +338,6 @@ test('Polling schemas (gateway.polling interval is not a number)', async (t) => 
 })
 
 test("Polling schemas (if service is down, schema shouldn't be changed)", async (t) => {
-  const clock = FakeTimers.install({
-    shouldClearNativeTimers: true,
-    shouldAdvanceTime: true,
-    advanceTimeDelta: 100
-  })
-
   const resolvers = {
     Query: {
       me: (root, args, context, info) => user
@@ -367,7 +359,6 @@ test("Polling schemas (if service is down, schema shouldn't be changed)", async 
   t.teardown(async () => {
     await gateway.close()
     await userService.close()
-    clock.uninstall()
   })
 
   userService.register(GQL, {
@@ -386,7 +377,7 @@ test("Polling schemas (if service is down, schema shouldn't be changed)", async 
   })
 
   await userService.listen({ port: 0 })
-  await clock.tickAsync()
+  await t.context.clock.tickAsync()
 
   const userServicePort = userService.server.address().port
 
@@ -402,7 +393,7 @@ test("Polling schemas (if service is down, schema shouldn't be changed)", async 
     }
   })
 
-  await clock.tickAsync()
+  await t.context.clock.tickAsync()
 
   {
     const { body } = await gateway.inject({
@@ -423,7 +414,7 @@ test("Polling schemas (if service is down, schema shouldn't be changed)", async 
       })
     })
 
-    await clock.tickAsync()
+    await t.context.clock.tickAsync()
 
     t.same(JSON.parse(body), {
       data: {
@@ -468,7 +459,7 @@ test("Polling schemas (if service is down, schema shouldn't be changed)", async 
   }
 
   await userService.close()
-  await clock.tickAsync(500)
+  await t.context.clock.tickAsync(500)
 
   {
     const { body } = await gateway.inject({
@@ -627,12 +618,6 @@ test('Polling schemas (if service is mandatory, exception should be thrown)', as
 })
 
 test('Polling schemas (cache should be cleared)', async (t) => {
-  const clock = FakeTimers.install({
-    shouldClearNativeTimers: true,
-    shouldAdvanceTime: true,
-    advanceTimeDelta: 100
-  })
-
   const user = {
     id: 'u1',
     name: 'John',
@@ -644,7 +629,6 @@ test('Polling schemas (cache should be cleared)', async (t) => {
   t.teardown(async () => {
     await gateway.close()
     await userService.close()
-    clock.uninstall()
   })
 
   userService.register(GQL, {
@@ -736,7 +720,7 @@ test('Polling schemas (cache should be cleared)', async (t) => {
   })
 
   for (let i = 0; i < 100; i++) {
-    await clock.tickAsync(100)
+    await t.context.clock.tickAsync(100)
   }
 
   // We need the event loop to actually spin twice to
@@ -801,12 +785,6 @@ test('Polling schemas (cache should be cleared)', async (t) => {
 })
 
 test('Polling schemas (should properly regenerate the schema when a downstream service restarts)', async (t) => {
-  const clock = FakeTimers.install({
-    shouldClearNativeTimers: true,
-    shouldAdvanceTime: true,
-    advanceTimeDelta: 100
-  })
-
   const oldSchema = `
     type Query {
       me: User
@@ -889,7 +867,6 @@ test('Polling schemas (should properly regenerate the schema when a downstream s
     await gateway.close()
     await userService.close()
     await restartedUserService.close()
-    clock.uninstall()
   })
 
   const refreshedSchema = `
@@ -927,7 +904,7 @@ test('Polling schemas (should properly regenerate the schema when a downstream s
   await restartedUserService.listen({ port: userServicePort })
 
   for (let i = 0; i < 100; i++) {
-    await clock.tickAsync(100)
+    await t.context.clock.tickAsync(100)
   }
 
   // We need the event loop to actually spin twice to
@@ -994,12 +971,6 @@ test('Polling schemas (should properly regenerate the schema when a downstream s
 test('Polling schemas (subscriptions should be handled)', async (t) => {
   t.plan(12)
 
-  const clock = FakeTimers.install({
-    shouldClearNativeTimers: true,
-    shouldAdvanceTime: true,
-    advanceTimeDelta: 100
-  })
-
   const user = {
     id: 'u1',
     name: 'John',
@@ -1039,7 +1010,6 @@ test('Polling schemas (subscriptions should be handled)', async (t) => {
   t.teardown(async () => {
     await gateway.close()
     await userService.close()
-    clock.uninstall()
   })
 
   userService.register(GQL, {
@@ -1185,7 +1155,7 @@ test('Polling schemas (subscriptions should be handled)', async (t) => {
 
   userService.graphql.defineResolvers(resolvers)
 
-  await clock.tickAsync(10000)
+  await t.context.clock.tickAsync(10000)
 
   // We need the event loop to actually spin twice to
   // be able to propagate the change

--- a/test/gateway/pollingInterval.js
+++ b/test/gateway/pollingInterval.js
@@ -19,7 +19,6 @@ test('Polling schemas with disable cache', async (t) => {
     shouldAdvanceTime: true,
     advanceTimeDelta: 40
   })
-  t.teardown(() => clock.uninstall())
 
   const resolvers = {
     Query: {
@@ -41,6 +40,7 @@ test('Polling schemas with disable cache', async (t) => {
   t.teardown(async () => {
     await gateway.close()
     await userService.close()
+    clock.uninstall()
   })
 
   userService.register(GQL, {
@@ -109,7 +109,6 @@ test('Polling schemas', async (t) => {
     shouldAdvanceTime: true,
     advanceTimeDelta: 40
   })
-  t.teardown(() => clock.uninstall())
 
   const resolvers = {
     Query: {
@@ -131,6 +130,7 @@ test('Polling schemas', async (t) => {
   t.teardown(async () => {
     await gateway.close()
     await userService.close()
+    clock.uninstall()
   })
 
   userService.register(GQL, {
@@ -236,7 +236,9 @@ test('Polling schemas', async (t) => {
   )
   userService.graphql.defineResolvers(resolvers)
 
-  await clock.tickAsync(2000)
+  for (let i = 0; i < 10; i++) {
+    await clock.tickAsync(200)
+  }
 
   // We need the event loop to actually spin twice to
   // be able to propagate the change
@@ -341,9 +343,8 @@ test("Polling schemas (if service is down, schema shouldn't be changed)", async 
   const clock = FakeTimers.install({
     shouldClearNativeTimers: true,
     shouldAdvanceTime: true,
-    advanceTimeDelta: 40
+    advanceTimeDelta: 100
   })
-  t.teardown(() => clock.uninstall())
 
   const resolvers = {
     Query: {
@@ -366,6 +367,7 @@ test("Polling schemas (if service is down, schema shouldn't be changed)", async 
   t.teardown(async () => {
     await gateway.close()
     await userService.close()
+    clock.uninstall()
   })
 
   userService.register(GQL, {
@@ -628,9 +630,8 @@ test('Polling schemas (cache should be cleared)', async (t) => {
   const clock = FakeTimers.install({
     shouldClearNativeTimers: true,
     shouldAdvanceTime: true,
-    advanceTimeDelta: 40
+    advanceTimeDelta: 100
   })
-  t.teardown(() => clock.uninstall())
 
   const user = {
     id: 'u1',
@@ -643,6 +644,7 @@ test('Polling schemas (cache should be cleared)', async (t) => {
   t.teardown(async () => {
     await gateway.close()
     await userService.close()
+    clock.uninstall()
   })
 
   userService.register(GQL, {
@@ -733,7 +735,9 @@ test('Polling schemas (cache should be cleared)', async (t) => {
     }
   })
 
-  await clock.tickAsync(10000)
+  for (let i = 0; i < 100; i++) {
+    await clock.tickAsync(100)
+  }
 
   // We need the event loop to actually spin twice to
   // be able to propagate the change
@@ -800,9 +804,9 @@ test('Polling schemas (should properly regenerate the schema when a downstream s
   const clock = FakeTimers.install({
     shouldClearNativeTimers: true,
     shouldAdvanceTime: true,
-    advanceTimeDelta: 40
+    advanceTimeDelta: 100
   })
-  t.teardown(() => clock.uninstall())
+
   const oldSchema = `
     type Query {
       me: User
@@ -885,6 +889,7 @@ test('Polling schemas (should properly regenerate the schema when a downstream s
     await gateway.close()
     await userService.close()
     await restartedUserService.close()
+    clock.uninstall()
   })
 
   const refreshedSchema = `
@@ -992,9 +997,8 @@ test('Polling schemas (subscriptions should be handled)', async (t) => {
   const clock = FakeTimers.install({
     shouldClearNativeTimers: true,
     shouldAdvanceTime: true,
-    advanceTimeDelta: 40
+    advanceTimeDelta: 100
   })
-  t.teardown(() => clock.uninstall())
 
   const user = {
     id: 'u1',
@@ -1035,6 +1039,7 @@ test('Polling schemas (subscriptions should be handled)', async (t) => {
   t.teardown(async () => {
     await gateway.close()
     await userService.close()
+    clock.uninstall()
   })
 
   userService.register(GQL, {

--- a/test/gateway/retry-failed-services.js
+++ b/test/gateway/retry-failed-services.js
@@ -288,8 +288,8 @@ test('gateway - should not call onGatewayReplaceSchemaHandler if the hook is not
     data: null
   })
 
-  for (let i = 0; i < 10; i++) {
-    await clock.tickAsync(1000)
+  for (let i = 0; i < 100; i++) {
+    await clock.tickAsync(100)
   }
 
   const res1 = await app.inject({
@@ -380,8 +380,8 @@ test('gateway - dont retry non-mandatory failed services on startup', async (t) 
     data: null
   })
 
-  for (let i = 0; i < 10; i++) {
-    await clock.tickAsync(1500)
+  for (let i = 0; i < 100; i++) {
+    await clock.tickAsync(150)
   }
 
   const res1 = await app.inject({
@@ -513,7 +513,7 @@ test('gateway - stop retrying after no. of retries exceeded', async (t) => {
 
   await app.ready()
 
-  for (let i = 0; i < 10; i++) {
-    await clock.tickAsync(1500)
+  for (let i = 0; i < 100; i++) {
+    await clock.tickAsync(150)
   }
 })

--- a/test/gateway/retry-failed-services.js
+++ b/test/gateway/retry-failed-services.js
@@ -189,8 +189,8 @@ test('gateway - retry mandatory failed services on startup', async (t) => {
     data: null
   })
 
-  for (let i = 0; i < 100; i++) {
-    await clock.tickAsync(200)
+  for (let i = 0; i < 200; i++) {
+    await clock.tickAsync(100)
   }
 
   const res1 = await app.inject({
@@ -228,7 +228,7 @@ test('gateway - should not call onGatewayReplaceSchemaHandler if the hook is not
   let service2 = null
   setTimeout(async () => {
     service2 = await createTestService(5111, postService.schema, postService.resolvers)
-  }, 5000)
+  }, 2000)
 
   const app = Fastify()
   t.teardown(async () => {
@@ -414,7 +414,7 @@ test('gateway - should log error if retry throws', async (t) => {
 
   let service2 = null
   setTimeout(async () => {
-    service2 = await createTestService(5113, postService.schema, postService.resolvers)
+    service2 = await createTestService(5114, postService.schema, postService.resolvers)
   }, 2000)
 
   const app = Fastify()
@@ -445,7 +445,7 @@ test('gateway - should log error if retry throws', async (t) => {
         },
         {
           name: 'post',
-          url: 'http://localhost:5113/graphql',
+          url: 'http://localhost:5114/graphql',
           mandatory: true
         }
       ],
@@ -502,7 +502,7 @@ test('gateway - stop retrying after no. of retries exceeded', async (t) => {
         },
         {
           name: 'post',
-          url: 'http://localhost:5114/graphql',
+          url: 'http://localhost:5115/graphql',
           mandatory: true
         }
       ],

--- a/test/gateway/retry-failed-services.js
+++ b/test/gateway/retry-failed-services.js
@@ -115,6 +115,7 @@ const postService = {
 test('gateway - retry mandatory failed services on startup', async (t) => {
   t.plan(5)
   const clock = FakeTimers.install({
+    shouldClearNativeTimers: true,
     shouldAdvanceTime: true,
     advanceTimeDelta: 100
   })
@@ -188,8 +189,8 @@ test('gateway - retry mandatory failed services on startup', async (t) => {
     data: null
   })
 
-  for (let i = 0; i < 10; i++) {
-    await clock.tickAsync(2000)
+  for (let i = 0; i < 100; i++) {
+    await clock.tickAsync(200)
   }
 
   const res1 = await app.inject({
@@ -217,6 +218,7 @@ test('gateway - retry mandatory failed services on startup', async (t) => {
 test('gateway - should not call onGatewayReplaceSchemaHandler if the hook is not specified', async (t) => {
   t.plan(2)
   const clock = FakeTimers.install({
+    shouldClearNativeTimers: true,
     shouldAdvanceTime: true,
     advanceTimeDelta: 100
   })
@@ -315,6 +317,7 @@ test('gateway - should not call onGatewayReplaceSchemaHandler if the hook is not
 test('gateway - dont retry non-mandatory failed services on startup', async (t) => {
   t.plan(2)
   const clock = FakeTimers.install({
+    shouldClearNativeTimers: true,
     shouldAdvanceTime: true,
     advanceTimeDelta: 100
   })
@@ -402,6 +405,7 @@ test('gateway - dont retry non-mandatory failed services on startup', async (t) 
 test('gateway - should log error if retry throws', async (t) => {
   t.plan(1)
   const clock = FakeTimers.install({
+    shouldClearNativeTimers: true,
     shouldAdvanceTime: true,
     advanceTimeDelta: 100
   })
@@ -464,6 +468,7 @@ test('gateway - should log error if retry throws', async (t) => {
 test('gateway - stop retrying after no. of retries exceeded', async (t) => {
   t.plan(1)
   const clock = FakeTimers.install({
+    shouldClearNativeTimers: true,
     shouldAdvanceTime: true,
     advanceTimeDelta: 100
   })

--- a/test/gateway/retry-failed-services.js
+++ b/test/gateway/retry-failed-services.js
@@ -123,7 +123,7 @@ test('gateway - retry mandatory failed services on startup', async (t) => {
   const service1 = await createTestService(0, userService.schema, userService.resolvers)
 
   let service2 = null
-  setTimeout(async () => {
+  clock.setTimeout(async () => {
     service2 = await createTestService(5113, postService.schema, postService.resolvers)
   }, 5000)
 
@@ -179,7 +179,7 @@ test('gateway - retry mandatory failed services on startup', async (t) => {
     body: JSON.stringify({ query })
   })
 
-  t.same(JSON.parse(res.body), {
+  t.same(await res.json(), {
     errors: [
       {
         message: 'Cannot query field "posts" on type "User".',
@@ -226,7 +226,7 @@ test('gateway - should not call onGatewayReplaceSchemaHandler if the hook is not
   const service1 = await createTestService(0, userService.schema, userService.resolvers)
 
   let service2 = null
-  setTimeout(async () => {
+  clock.setTimeout(async () => {
     service2 = await createTestService(5111, postService.schema, postService.resolvers)
   }, 2000)
 
@@ -278,7 +278,7 @@ test('gateway - should not call onGatewayReplaceSchemaHandler if the hook is not
     body: JSON.stringify({ query })
   })
 
-  t.same(JSON.parse(res.body), {
+  t.same(await res.json(), {
     errors: [
       {
         message: 'Cannot query field "posts" on type "User".',
@@ -370,7 +370,7 @@ test('gateway - dont retry non-mandatory failed services on startup', async (t) 
     body: JSON.stringify({ query })
   })
 
-  t.same(JSON.parse(res.body), {
+  t.same(await res.json(), {
     errors: [
       {
         message: 'Cannot query field "posts" on type "User".',
@@ -391,7 +391,7 @@ test('gateway - dont retry non-mandatory failed services on startup', async (t) 
     body: JSON.stringify({ query })
   })
 
-  t.same(JSON.parse(res1.body), {
+  t.same(await res1.json(), {
     errors: [
       {
         message: 'Cannot query field "posts" on type "User".',
@@ -413,7 +413,7 @@ test('gateway - should log error if retry throws', async (t) => {
   const service1 = await createTestService(0, userService.schema, userService.resolvers)
 
   let service2 = null
-  setTimeout(async () => {
+  clock.setTimeout(async () => {
     service2 = await createTestService(5114, postService.schema, postService.resolvers)
   }, 2000)
 

--- a/test/gateway/value-types.js
+++ b/test/gateway/value-types.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('tap')
+const { test, t } = require('tap')
 const Fastify = require('fastify')
 const FakeTimers = require('@sinonjs/fake-timers')
 const { promisify } = require('util')
@@ -485,6 +485,18 @@ const commentMutation = `
   }  
 `
 
+t.beforeEach(({ context }) => {
+  context.clock = FakeTimers.install({
+    shouldClearNativeTimers: true,
+    shouldAdvanceTime: true,
+    advanceTimeDelta: 100
+  })
+})
+
+t.afterEach(({ context }) => {
+  context.clock.uninstall()
+})
+
 test('Should be able to query with value types', async (t) => {
   const [userService, userServicePort] = await createService(t, userSchema, userResolvers)
   const [postService, postServicePort] = await createService(t, postSchema, postResolvers)
@@ -705,13 +717,6 @@ test('Should be able to query top-level with value types', async (t) => {
 })
 
 test('Should be able to query with value types and polling', async (t) => {
-  const clock = FakeTimers.install({
-    shouldClearNativeTimers: true,
-    shouldAdvanceTime: true,
-    advanceTimeDelta: 40
-  })
-  t.teardown(() => clock.uninstall())
-
   const [userService, userServicePort] = await createService(t, userSchema, userResolvers)
   const [postService, postServicePort] = await createService(t, postSchema, postResolvers)
   const [commentService, commentServicePort] = await createService(t, commentSchema, commentResolvers)
@@ -798,7 +803,7 @@ test('Should be able to query with value types and polling', async (t) => {
     }
   })
 
-  await clock.tickAsync(2000)
+  await t.context.clock.tickAsync(2000)
 
   // We need the event loop to actually spin twice to
   // be able to propagate the change

--- a/test/gateway/value-types.js
+++ b/test/gateway/value-types.js
@@ -706,6 +706,7 @@ test('Should be able to query top-level with value types', async (t) => {
 
 test('Should be able to query with value types and polling', async (t) => {
   const clock = FakeTimers.install({
+    shouldClearNativeTimers: true,
     shouldAdvanceTime: true,
     advanceTimeDelta: 40
   })


### PR DESCRIPTION
This pull requests properly clears native timers on the installation of sinon/fake-timers.