### PR TITLE
Properly clone context for batched queries

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -358,7 +358,12 @@ module.exports = async function (app, opts) {
 
       return Promise.all(request.body.map(async (r, operationId) => {
         // Create individual reqs for multiple operations, otherwise reference the original req
-        const operationReq = operationsCount > 1 ? Object.create(request) : request
+        const operationReq = operationsCount > 1
+          ? {
+              ...request,
+              [kRequestContext]: Object.create(request[kRequestContext])
+            }
+          : request
 
         Object.assign(operationReq[kRequestContext], { operationId })
 

--- a/test/hooks-with-batching.js
+++ b/test/hooks-with-batching.js
@@ -1,0 +1,78 @@
+'use strict'
+
+const { test } = require('tap')
+const Fastify = require('fastify')
+const sinon = require('sinon')
+const GQL = require('..')
+
+test('batched query has an individual context for each operation through all the lifecycle hooks', async (t) => {
+  const app = Fastify()
+
+  const preParsingSpy = sinon.spy()
+  const preValidationSpy = sinon.spy()
+  const preExecutionSpy = sinon.spy()
+  const onResolutionSpy = sinon.spy()
+
+  const schema = `
+      type Query {
+        test: String
+      }
+    `
+
+  const resolvers = {
+    test: () => 'test'
+  }
+
+  await app.register(GQL, {
+    schema,
+    resolvers,
+    allowBatchedQueries: true
+  })
+
+  app.graphql.addHook('preParsing', (_, __, ctx) => {
+    preParsingSpy(ctx.operationId, ctx.operationsCount, ctx.__currentQuery)
+  })
+
+  app.graphql.addHook('preValidation', (_, __, ctx) => {
+    preValidationSpy(ctx.operationId, ctx.operationsCount, ctx.__currentQuery)
+  })
+
+  app.graphql.addHook('preExecution', (_, __, ctx) => {
+    preExecutionSpy(ctx.operationId, ctx.operationsCount, ctx.__currentQuery)
+  })
+
+  app.graphql.addHook('onResolution', (_, ctx) => {
+    onResolutionSpy(ctx.operationId, ctx.operationsCount, ctx.__currentQuery)
+  })
+
+  await app.inject({
+    method: 'POST',
+    url: '/graphql',
+    body: [
+      {
+        operationName: 'TestQuery',
+        query: 'query TestQuery { test }'
+      },
+      {
+        operationName: 'DoubleQuery',
+        query: 'query DoubleQuery { test }'
+      }
+    ]
+  })
+
+  sinon.assert.calledTwice(preParsingSpy)
+  sinon.assert.calledWith(preParsingSpy, 0, 2, sinon.match(/TestQuery/))
+  sinon.assert.calledWith(preParsingSpy, 1, 2, sinon.match(/DoubleQuery/))
+
+  sinon.assert.calledTwice(preValidationSpy)
+  sinon.assert.calledWith(preValidationSpy, 0, 2, sinon.match(/TestQuery/))
+  sinon.assert.calledWith(preValidationSpy, 1, 2, sinon.match(/DoubleQuery/))
+
+  sinon.assert.calledTwice(preExecutionSpy)
+  sinon.assert.calledWith(preExecutionSpy, 0, 2, sinon.match(/TestQuery/))
+  sinon.assert.calledWith(preExecutionSpy, 1, 2, sinon.match(/DoubleQuery/))
+
+  sinon.assert.calledTwice(onResolutionSpy)
+  sinon.assert.calledWith(onResolutionSpy, 0, 2, sinon.match(/TestQuery/))
+  sinon.assert.calledWith(onResolutionSpy, 1, 2, sinon.match(/DoubleQuery/))
+})


### PR DESCRIPTION
fixes #858

- Create a shallow copy of the context inside `operationReq` to make sure that context's top level properties are cloned and not just referenced.
- Add more tests to make sure that the new context's top properties remain isolated through all the request lifecycle.

Request before the fix:
![request_before](https://user-images.githubusercontent.com/14996002/187700292-b7aa6c6a-b435-4c7a-82e5-55fd484296af.png)

Request after the fix:
![request_after](https://user-images.githubusercontent.com/14996002/187700299-42301aec-75d4-465e-843a-45ee5e270616.png)