### PR TITLE
docs: replace uses of variadic `.listen` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ app.get('/', async function (req, reply) {
   return reply.graphql(query)
 })
 
-app.listen(3000)
+app.listen({ port: 3000 })
 ```
 
 ## Examples

--- a/bench/gateway-service-1.js
+++ b/bench/gateway-service-1.js
@@ -58,4 +58,4 @@ app.register(mercurius, {
   jit: 1
 })
 
-app.listen(3001)
+app.listen({ port: 3001 })

--- a/bench/gateway-service-2.js
+++ b/bench/gateway-service-2.js
@@ -88,4 +88,4 @@ app.register(mercurius, {
   jit: 1
 })
 
-app.listen(3002)
+app.listen({ port: 3002 })

--- a/bench/gateway.js
+++ b/bench/gateway.js
@@ -19,4 +19,4 @@ app.register(mercurius, {
   jit: 1
 })
 
-app.listen(3000)
+app.listen({ port: 3000 })

--- a/bench/standalone.js
+++ b/bench/standalone.js
@@ -13,4 +13,4 @@ app.register(mercurius, {
   jit: 1
 })
 
-app.listen(3000)
+app.listen({ port: 3000 })

--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -535,7 +535,7 @@ app.register(mercurius, {
   resolvers
 })
 
-app.listen(3000)
+app.listen({ port: 3000 })
 ```
 
 #### Status code

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -75,7 +75,7 @@ app.get('/', async function (req, reply) {
   return app.graphql(query)
 })
 
-app.listen(3000)
+app.listen({ port: 3000 })
 ```
 
 ### Federation with \_\_resolveReference caching
@@ -143,7 +143,7 @@ app.get('/', async function (req, reply) {
   return app.graphql(query)
 })
 
-app.listen(3000)
+app.listen({ port: 3000 })
 ```
 
 ### Use GraphQL server as a Gateway for federated schemas
@@ -195,7 +195,7 @@ gateway.register(mercurius, {
   }
 })
 
-await gateway.listen(4000)
+await gateway.listen({ port: 4000 })
 ```
 
 #### Periodically refresh federated schemas in Gateway mode
@@ -220,7 +220,7 @@ gateway.register(mercurius, {
   }
 })
 
-gateway.listen(3001)
+gateway.listen({ port: 3001 })
 ```
 
 #### Programmatically refresh federated schemas in Gateway mode
@@ -249,7 +249,7 @@ server.register(mercurius, {
   }
 })
 
-server.listen(3002)
+server.listen({ port: 3002 })
 
 setTimeout(async () => {
   const schema = await server.graphql.gateway.refresh()
@@ -306,7 +306,7 @@ server.register(mercurius, {
   }
 })
 
-await server.listen(3002)
+await server.listen({ port: 3002 })
 
 server.graphql.gateway.serviceMap.user.setSchema(`
   extend type Query {
@@ -390,7 +390,7 @@ server.register(mercurius, {
   pollingInterval: 2000
 })
 
-server.listen(3002)
+server.listen({ port: 3002 })
 ```
 
 #### Using a custom errorHandler for handling downstream service errors in Gateway mode
@@ -426,7 +426,7 @@ server.register(mercurius, {
   pollingInterval: 2000
 })
 
-server.listen(3002)
+server.listen({ port: 3002 })
 ```
 
 _Note: The default behavior of `errorHandler` is call `errorFormatter` to send the result. When is provided an `errorHandler` make sure to **call `errorFormatter` manually if needed**._
@@ -459,5 +459,5 @@ server.register(mercurius, {
   pollingInterval: 2000
 })
 
-server.listen(3002)
+server.listen({ port: 3002 })
 ```

--- a/docs/integrations/nexus.md
+++ b/docs/integrations/nexus.md
@@ -70,7 +70,7 @@ app.get("/", async function (req, reply) {
   return reply.graphql(query);
 });
 
-app.listen(3000);
+app.listen({ port: 3000 });
 ```
 
 If you run this, you will get type definitions and a generated GraphQL based on your code:

--- a/docs/integrations/open-telemetry.md
+++ b/docs/integrations/open-telemetry.md
@@ -83,7 +83,7 @@ service.register(mercurius, {
   federationMetadata: true
 })
 
-service.listen(4001, 'localhost', err => {
+service.listen({ port: 4001, host: 'localhost' }, err => {
   if (err) {
     console.error(err)
     process.exit(1)
@@ -116,7 +116,7 @@ gateway.register(mercurius, {
   }
 })
 
-gateway.listen(3000, 'localhost', err => {
+gateway.listen({ port: 3000, host: 'localhost' }, err => {
   if (err) {
     process.exit(1)
   }

--- a/docs/integrations/prisma.md
+++ b/docs/integrations/prisma.md
@@ -153,7 +153,7 @@ app.register(mercurius, {
   graphiql: true
 })
 
-app.listen(3000)
+app.listen({ port: 3000 })
   .then(() => console.log(`🚀 Server ready at http://localhost:3000/graphiql`))
 
 ```

--- a/docs/integrations/type-graphql.md
+++ b/docs/integrations/type-graphql.md
@@ -92,7 +92,7 @@ async function main() {
     return reply.graphql(query);
   });
 
-  app.listen(3000);
+  app.listen({ port: 3000 });
 }
 
 main().catch(console.error);

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -63,7 +63,7 @@ app.register(AltairFastify, {
   endpointURL: '/graphql'
 })
 
-app.listen(3000)
+app.listen({ port: 3000 })
 ```
 
 And it will be available at `http://localhost:3000/altair` 🎉
@@ -101,7 +101,7 @@ app.register(mercuriusApolloRegistry, {
   apiKey: 'REPLACE-THIS-VALUE-WITH-APOLLO-API-KEY'
 })
 
-app.listen(3000)
+app.listen({ port: 3000 })
 ```
 
 ## mercurius-apollo-tracing

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -31,4 +31,4 @@ app.get('/', async function (req, reply) {
   return reply.graphql(query)
 })
 
-app.listen(3000)
+app.listen({ port: 3000 })

--- a/examples/custom-http-behaviour.js
+++ b/examples/custom-http-behaviour.js
@@ -35,4 +35,4 @@ app.register(mercurius, {
   errorFormatter
 })
 
-app.listen(3000)
+app.listen({ port: 3000 })

--- a/examples/disable-introspection.js
+++ b/examples/disable-introspection.js
@@ -33,4 +33,4 @@ app.get('/', async function (req, reply) {
   return reply.graphql(query)
 })
 
-app.listen(3000)
+app.listen({ port: 3000 })

--- a/examples/executable-schema.js
+++ b/examples/executable-schema.js
@@ -27,4 +27,4 @@ app.get('/', async function (req, reply) {
   return reply.graphql(query)
 })
 
-app.listen(3000)
+app.listen({ port: 3000 })

--- a/examples/full-ws-transport.js
+++ b/examples/full-ws-transport.js
@@ -87,4 +87,4 @@ app.register(mercurius, {
   }
 })
 
-app.listen(4000)
+app.listen({ port: 4000 })

--- a/examples/gateway-subscription.js
+++ b/examples/gateway-subscription.js
@@ -277,7 +277,7 @@ async function start () {
     }
   })
 
-  await gateway.listen(4000)
+  await gateway.listen({ port: 4000 })
 }
 
 start()

--- a/examples/gateway.js
+++ b/examples/gateway.js
@@ -185,7 +185,7 @@ async function start () {
     }
   })
 
-  await gateway.listen(4000)
+  await gateway.listen({ port: 4000 })
 }
 
 start()

--- a/examples/hooks-gateway.js
+++ b/examples/hooks-gateway.js
@@ -220,7 +220,7 @@ async function start () {
     console.log('onGatewayReplaceSchema called')
   })
 
-  await gateway.listen(4000)
+  await gateway.listen({ port: 4000 })
 }
 
 start()

--- a/examples/hooks-subscription.js
+++ b/examples/hooks-subscription.js
@@ -74,7 +74,7 @@ async function start () {
     console.log('onSubscriptionEnd called')
   })
 
-  await app.listen(3000)
+  await app.listen({ port: 3000 })
 }
 
 start()

--- a/examples/hooks.js
+++ b/examples/hooks.js
@@ -57,7 +57,7 @@ async function start () {
     return reply.graphql(query)
   })
 
-  app.listen(3000)
+  app.listen({ port: 3000 })
 }
 
 start()

--- a/examples/loaders.js
+++ b/examples/loaders.js
@@ -65,4 +65,4 @@ app.register(mercurius, {
   graphiql: true
 })
 
-app.listen(3000)
+app.listen({ port: 3000 })

--- a/examples/persisted-queries/index.js
+++ b/examples/persisted-queries/index.js
@@ -29,4 +29,4 @@ app.register(mercurius, {
   graphiql: true
 })
 
-app.listen(3000)
+app.listen({ port: 3000 })

--- a/examples/playground.js
+++ b/examples/playground.js
@@ -31,4 +31,4 @@ app.get('/', async function (req, reply) {
   return reply.graphql(query)
 })
 
-app.listen(3000)
+app.listen({ port: 3000 })

--- a/examples/subscription/mqemitter-mongodb-subscription.js
+++ b/examples/subscription/mqemitter-mongodb-subscription.js
@@ -81,7 +81,7 @@ const start = async () => {
     })
 
     // start server
-    await app.listen(3000)
+    await app.listen({ port: 3000 })
   } catch (error) {
     app.log.error(error)
   }

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -218,7 +218,7 @@ app.get('/', async function (req, reply) {
   return await reply.graphql(query)
 })
 
-app.listen(3000)
+app.listen({ port: 3000 })
 
 function makeGraphqlServer (options: MercuriusOptions) {
   const app = Fastify()


### PR DESCRIPTION
The documentation references `.listen(<port>)` in several places, but this variadic function is deprecated in Fastify v4 and throws this warning:

> (node:254) [FSTDEP011] FastifyDeprecation: Variadic listen method is deprecated. Please use ".listen(optionsObject)" instead. The variadic signature will be removed in `fastify@5`.

Since the current `package.json` requires Fastify v4+, this should be safe to do: https://github.com/mercurius-js/mercurius/blob/bbb8b269344f04ad9a50ae9210c69d31761ab6a7/package.json#L44

Deprecation guide: https://github.com/fastify/fastify/blob/2fd918298d55aaab74585c0b71081ad40988b280/docs/Guides/Migration-Guide-V4.md#deprecation-of-variadic-listen-signature