### PR TITLE
fix(types): correct `jit` default value

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -444,7 +444,7 @@ export interface MercuriusCommonOptions {
   ide?: boolean | 'graphiql';
   /**
    * The minimum number of execution a query needs to be executed before being jit'ed.
-   * @default true
+   * @default 0 - disabled
    */
   jit?: number;
   /**


### PR DESCRIPTION
The existing types for the `jit` property were misleading. The value defaults to `0`, which means that queries will not be `jit`-ed.

https://github.com/mercurius-js/mercurius/blob/bbb8b269344f04ad9a50ae9210c69d31761ab6a7/index.js#L80

Here's the code that determines if `jit` should happen:

https://github.com/mercurius-js/mercurius/blob/bbb8b269344f04ad9a50ae9210c69d31761ab6a7/index.js#L613

On the first request, `cache` is `undefined`, so `jit` does not occur:

![Screen Shot 2022-09-15 at 12 15 34](https://user-images.githubusercontent.com/630449/190479517-33117eb3-28d7-4aa7-8582-bfb3b7c6b686.png)

Then, on subsequent requests, the request count is `1`, so again `jit` does not occur:

![Screen Shot 2022-09-15 at 12 16 19](https://user-images.githubusercontent.com/630449/190479659-de102214-a37b-42c5-8f11-2317811c3d9c.png)
