### PR TITLE
fix: rendering logo on website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-
-![Mercurius Logo](https://github.com/mercurius-js/graphics/blob/main/mercurius-horizontal.svg)
+![Mercurius Logo](https://raw.githubusercontent.com/mercurius-js/graphics/main/mercurius-horizontal.svg)
 
 # mercurius
 


### PR DESCRIPTION
On [mercurius.dev](https://mercurius.dev/#/), the Mercurius logo is not rendering.
This PR aims to fix this.