### PR TITLE
Fix: subscription.onConnect types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -527,7 +527,7 @@ export interface MercuriusCommonOptions {
         onConnect?: (data: {
           type: 'connection_init';
           payload: any;
-        }) => Record<string, any> | Promise<Record<string, any>>;
+        }) => Record<string, any> | Promise<Record<string, any>> | boolean;
         onDisconnect?: (context: MercuriusContext) => void | Promise<void>;
         keepAlive?: number,
         fullWsTransport?: boolean,

--- a/index.d.ts
+++ b/index.d.ts
@@ -527,7 +527,7 @@ export interface MercuriusCommonOptions {
         onConnect?: (data: {
           type: 'connection_init';
           payload: any;
-        }) => Record<string, any> | Promise<Record<string, any>> | boolean;
+        }) => any;
         onDisconnect?: (context: MercuriusContext) => void | Promise<void>;
         keepAlive?: number,
         fullWsTransport?: boolean,

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -544,6 +544,14 @@ app.register(mercurius, {
   schema,
   resolvers,
   subscription: {
+    onConnect: () => true
+  }
+})
+
+app.register(mercurius, {
+  schema,
+  resolvers,
+  subscription: {
     emitter
   }
 })


### PR DESCRIPTION
This PR extends the return types of `subscription.onConnect` to include `boolean` type

The docs mention:

> subscription.onConnect: Function A function which can be used to validate the connection_init payload. If defined it should return a **truthy value** to authorize the connection. If it returns an object the subscription context will be extended with the returned object.

closes #871 

cc @simoneb 