### PR TITLE
Clean up index.js file from gateway init instructions #887

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const {
 const { buildExecutionContext } = require('graphql/execution/execute')
 const queryDepth = require('./lib/queryDepth')
 const buildFederationSchema = require('./lib/federation')
-const buildGateway = require('./lib/gateway')
+const buildGateway = require('./lib/gateway/build-gateway')
 const mq = require('mqemitter')
 const { PubSub, withFilter } = require('./lib/subscriber')
 const persistedQueryDefaults = require('./lib/persistedQueryDefaults')
@@ -42,7 +42,13 @@ const {
 } = require('./lib/errors')
 const { Hooks, assignLifeCycleHooksToContext, assignApplicationLifecycleHooksToContext } = require('./lib/hooks')
 const { kLoaders, kFactory, kSubscriptionFactory, kHooks } = require('./lib/symbols')
-const { preParsingHandler, preValidationHandler, preExecutionHandler, onResolutionHandler, onGatewayReplaceSchemaHandler } = require('./lib/handlers')
+const {
+  preParsingHandler,
+  preValidationHandler,
+  preExecutionHandler,
+  onResolutionHandler,
+  onGatewayReplaceSchemaHandler
+} = require('./lib/handlers')
 
 // Required for module bundlers
 // istanbul ignore next
@@ -632,7 +638,11 @@ const plugin = fp(async function (app, opts) {
     let modifiedSchema
     let modifiedDocument
     if (context.preExecution !== null) {
-      ({ modifiedSchema, modifiedDocument } = await preExecutionHandler({ schema: fastifyGraphQl.schema, document, context }))
+      ({ modifiedSchema, modifiedDocument } = await preExecutionHandler({
+        schema: fastifyGraphQl.schema,
+        document,
+        context
+      }))
     }
 
     // minJit is 0 by default

--- a/index.js
+++ b/index.js
@@ -119,7 +119,6 @@ const plugin = fp(async function (app, opts) {
   }
 
   const root = {}
-  let schema = opts.schema
   const subscriptionOpts = opts.subscription
   let emitter
 
@@ -153,6 +152,16 @@ const plugin = fp(async function (app, opts) {
     fastifyGraphQl.pubsub = subscriber
   }
 
+  let schema = opts.schema
+  let gateway
+  let lruGatewayResolvers
+  if (opts.gateway) {
+    lruGatewayResolvers = buildCache(opts)
+    gateway = await initGateway(opts, fastifyGraphQl, app)
+
+    schema = gateway.schema
+  }
+
   if (Array.isArray(schema)) {
     schema = schema.join('\n')
   }
@@ -176,15 +185,6 @@ const plugin = fp(async function (app, opts) {
         })
         : undefined
     })
-  }
-
-  let gateway
-  let lruGatewayResolvers
-  if (opts.gateway) {
-    lruGatewayResolvers = buildCache(opts)
-    gateway = await initGateway(opts, schema, fastifyGraphQl, app)
-
-    schema = gateway.schema
   }
 
   fastifyGraphQl.schema = schema

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const {
 const { buildExecutionContext } = require('graphql/execution/execute')
 const queryDepth = require('./lib/queryDepth')
 const buildFederationSchema = require('./lib/federation')
-const buildGateway = require('./lib/gateway/build-gateway')
+const { buildGateway, validateGateway } = require('./lib/gateway')
 const mq = require('mqemitter')
 const { PubSub, withFilter } = require('./lib/subscriber')
 const persistedQueryDefaults = require('./lib/persistedQueryDefaults')
@@ -157,27 +157,8 @@ const plugin = fp(async function (app, opts) {
     fastifyGraphQl.pubsub = subscriber
   }
 
-  if (gateway && (schema || opts.resolvers || opts.loaders)) {
-    throw new MER_ERR_INVALID_OPTS('Adding "schema", "resolvers" or "loaders" to plugin options when plugin is running in gateway mode is not allowed')
-  }
-
-  if (gateway && Array.isArray(gateway.services)) {
-    const serviceNames = new Set()
-    for (const service of gateway.services) {
-      if (typeof service !== 'object') {
-        throw new MER_ERR_INVALID_OPTS('gateway: all "services" must be objects')
-      }
-      if (typeof service.name !== 'string') {
-        throw new MER_ERR_INVALID_OPTS('gateway: all "services" must have a "name" String property')
-      }
-      if (serviceNames.has(service.name)) {
-        throw new MER_ERR_INVALID_OPTS(`gateway: all "services" must have a unique "name": "${service.name}" is already used`)
-      }
-      serviceNames.add(service.name)
-      if (typeof service.url !== 'string' && (!Array.isArray(service.url) || service.url.length === 0 || !service.url.every(url => typeof url === 'string'))) {
-        throw new MER_ERR_INVALID_OPTS('gateway: all "services" must have an "url" String, or a non-empty Array of String, property')
-      }
-    }
+  if (gateway) {
+    validateGateway(schema, gateway, opts)
   }
 
   if (Array.isArray(schema)) {

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -2,6 +2,9 @@
 
 const buildGateway = require('./gateway/build-gateway')
 const { MER_ERR_INVALID_OPTS } = require('./errors')
+const { assignApplicationLifecycleHooksToContext } = require('./hooks')
+const { kHooks } = require('./symbols')
+const { onGatewayReplaceSchemaHandler } = require('./handlers')
 
 function validateGateway (schema, gateway, opts) {
   if (schema || opts.resolvers || opts.loaders) {
@@ -28,7 +31,90 @@ function validateGateway (schema, gateway, opts) {
   }
 }
 
+async function initGateway (gatewayOpts, fastifyGraphQl, app) {
+  let gatewayRetryIntervalTimer = null
+  const retryServicesCount = gatewayOpts && gatewayOpts.retryServicesCount ? gatewayOpts.retryServicesCount : 10
+
+  const retryInterval = gatewayOpts.retryServicesInterval || 3000
+  const gateway = await buildGateway(gatewayOpts, app)
+
+  const serviceMap = Object.values(gateway.serviceMap)
+  const failedMandatoryServices = serviceMap.filter(service => !!service.error && service.mandatory)
+
+  if (failedMandatoryServices.length) {
+    gatewayRetryIntervalTimer = retryServices(retryInterval)
+    gatewayRetryIntervalTimer.unref()
+  }
+
+  let gatewayInterval = null
+
+  if (gatewayOpts.pollingInterval !== undefined) {
+    if (typeof gatewayOpts.pollingInterval === 'number') {
+      gatewayInterval = setInterval(async () => {
+        try {
+          const context = assignApplicationLifecycleHooksToContext({}, fastifyGraphQl[kHooks])
+          const schema = await gateway.refresh()
+          if (schema !== null) {
+            // Trigger onGatewayReplaceSchema hook
+            if (context.onGatewayReplaceSchema !== null) {
+              await onGatewayReplaceSchemaHandler(context, { instance: app, schema })
+            }
+            fastifyGraphQl.replaceSchema(schema)
+          }
+        } catch (error) {
+          app.log.error(error)
+        }
+      }, gatewayOpts.pollingInterval)
+    } else {
+      app.log.warn(`Expected a number for 'gateway.pollingInterval', received: ${typeof gatewayOpts.pollingInterval}`)
+    }
+  }
+
+  app.onClose((fastify, next) => {
+    gateway.close()
+    if (gatewayInterval !== null) {
+      clearInterval(gatewayInterval)
+    }
+    if (gatewayRetryIntervalTimer !== null) {
+      clearInterval(gatewayRetryIntervalTimer)
+    }
+    setImmediate(next)
+  })
+
+  fastifyGraphQl.gateway = gateway
+  return gateway
+
+  function retryServices (interval) {
+    let retryCount = 0
+    let isRetry = true
+
+    return setInterval(async () => {
+      try {
+        if (retryCount === retryServicesCount) {
+          clearInterval(gatewayRetryIntervalTimer)
+          isRetry = false
+        }
+        retryCount++
+
+        const context = assignApplicationLifecycleHooksToContext({}, fastifyGraphQl[kHooks])
+        const schema = await gateway.refresh(isRetry)
+        /* istanbul ignore next */
+        if (schema !== null) {
+          clearInterval(gatewayRetryIntervalTimer)
+          // Trigger onGatewayReplaceSchema hook
+          if (context.onGatewayReplaceSchema !== null) {
+            await onGatewayReplaceSchemaHandler(context, { instance: app, schema })
+          }
+          fastifyGraphQl.replaceSchema(schema)
+        }
+      } catch (error) {
+        app.log.error(error)
+      }
+    }, interval)
+  }
+}
+
 module.exports = {
-  buildGateway,
+  initGateway,
   validateGateway
 }

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const buildGateway = require('./gateway/build-gateway')
+const { MER_ERR_INVALID_OPTS } = require('./errors')
+
+function validateGateway (schema, gateway, opts) {
+  if (schema || opts.resolvers || opts.loaders) {
+    throw new MER_ERR_INVALID_OPTS('Adding "schema", "resolvers" or "loaders" to plugin options when plugin is running in gateway mode is not allowed')
+  }
+
+  if (Array.isArray(gateway.services)) {
+    const serviceNames = new Set()
+    for (const service of gateway.services) {
+      if (typeof service !== 'object') {
+        throw new MER_ERR_INVALID_OPTS('gateway: all "services" must be objects')
+      }
+      if (typeof service.name !== 'string') {
+        throw new MER_ERR_INVALID_OPTS('gateway: all "services" must have a "name" String property')
+      }
+      if (serviceNames.has(service.name)) {
+        throw new MER_ERR_INVALID_OPTS(`gateway: all "services" must have a unique "name": "${service.name}" is already used`)
+      }
+      serviceNames.add(service.name)
+      if (typeof service.url !== 'string' && (!Array.isArray(service.url) || service.url.length === 0 || !service.url.every(url => typeof url === 'string'))) {
+        throw new MER_ERR_INVALID_OPTS('gateway: all "services" must have an "url" String, or a non-empty Array of String, property')
+      }
+    }
+  }
+}
+
+module.exports = {
+  buildGateway,
+  validateGateway
+}

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const buildGateway = require('./gateway/build-gateway')
-const { MER_ERR_INVALID_OPTS, MER_ERR_GQL_GATEWAY } = require('./errors')
+const { MER_ERR_INVALID_OPTS, MER_ERR_GQL_GATEWAY, MER_ERR_GQL_GATEWAY_INIT } = require('./errors')
 const { assignApplicationLifecycleHooksToContext } = require('./hooks')
 const { kHooks } = require('./symbols')
 const { onGatewayReplaceSchemaHandler } = require('./handlers')
@@ -29,6 +29,8 @@ function validateGateway (opts) {
         throw new MER_ERR_INVALID_OPTS('gateway: all "services" must have an "url" String, or a non-empty Array of String, property')
       }
     }
+  } else {
+    throw new MER_ERR_GQL_GATEWAY_INIT('The "services" attribute cannot be undefined')
   }
 }
 

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -6,7 +6,8 @@ const { assignApplicationLifecycleHooksToContext } = require('./hooks')
 const { kHooks } = require('./symbols')
 const { onGatewayReplaceSchemaHandler } = require('./handlers')
 
-function validateGateway (schema, gateway, opts) {
+function validateGateway (schema, opts) {
+  const gateway = opts.gateway
   if (schema || opts.resolvers || opts.loaders) {
     throw new MER_ERR_INVALID_OPTS('Adding "schema", "resolvers" or "loaders" to plugin options when plugin is running in gateway mode is not allowed')
   }
@@ -31,7 +32,10 @@ function validateGateway (schema, gateway, opts) {
   }
 }
 
-async function initGateway (gatewayOpts, fastifyGraphQl, app) {
+async function initGateway (opts, schema, fastifyGraphQl, app) {
+  const gatewayOpts = opts.gateway
+  validateGateway(schema, opts)
+
   let gatewayRetryIntervalTimer = null
   const retryServicesCount = gatewayOpts && gatewayOpts.retryServicesCount ? gatewayOpts.retryServicesCount : 10
 

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const buildGateway = require('./gateway/build-gateway')
-const { MER_ERR_INVALID_OPTS } = require('./errors')
+const { MER_ERR_INVALID_OPTS, MER_ERR_GQL_GATEWAY } = require('./errors')
 const { assignApplicationLifecycleHooksToContext } = require('./hooks')
 const { kHooks } = require('./symbols')
 const { onGatewayReplaceSchemaHandler } = require('./handlers')
@@ -82,6 +82,17 @@ async function initGateway (gatewayOpts, fastifyGraphQl, app) {
   })
 
   fastifyGraphQl.gateway = gateway
+  fastifyGraphQl.extendSchema = function () {
+    throw new MER_ERR_GQL_GATEWAY('Calling extendSchema method when plugin is running in gateway mode is not allowed')
+  }
+
+  fastifyGraphQl.defineResolvers = function () {
+    throw new MER_ERR_GQL_GATEWAY('Calling defineResolvers method when plugin is running in gateway mode is not allowed')
+  }
+
+  fastifyGraphQl.defineLoaders = function () {
+    throw new MER_ERR_GQL_GATEWAY('Calling defineLoaders method when plugin is running in gateway mode is not allowed')
+  }
   return gateway
 
   function retryServices (interval) {

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -6,9 +6,9 @@ const { assignApplicationLifecycleHooksToContext } = require('./hooks')
 const { kHooks } = require('./symbols')
 const { onGatewayReplaceSchemaHandler } = require('./handlers')
 
-function validateGateway (schema, opts) {
+function validateGateway (opts) {
   const gateway = opts.gateway
-  if (schema || opts.resolvers || opts.loaders) {
+  if (opts.schema || opts.resolvers || opts.loaders) {
     throw new MER_ERR_INVALID_OPTS('Adding "schema", "resolvers" or "loaders" to plugin options when plugin is running in gateway mode is not allowed')
   }
 
@@ -32,10 +32,10 @@ function validateGateway (schema, opts) {
   }
 }
 
-async function initGateway (opts, schema, fastifyGraphQl, app) {
-  const gatewayOpts = opts.gateway
-  validateGateway(schema, opts)
+async function initGateway (opts, fastifyGraphQl, app) {
+  validateGateway(opts)
 
+  const gatewayOpts = opts.gateway
   let gatewayRetryIntervalTimer = null
   const retryServicesCount = gatewayOpts && gatewayOpts.retryServicesCount ? gatewayOpts.retryServicesCount : 10
 

--- a/lib/gateway/build-gateway.js
+++ b/lib/gateway/build-gateway.js
@@ -7,18 +7,18 @@ const {
   Kind
 } = require('graphql')
 const { Factory } = require('single-user-cache')
-const buildFederatedSchema = require('./federation')
-const buildServiceMap = require('./gateway/service-map')
+const buildFederatedSchema = require('../federation')
+const buildServiceMap = require('./service-map')
 const {
   makeResolver,
   createQueryOperation,
   createFieldResolverOperation,
   createEntityReferenceResolverOperation,
   kEntityResolvers
-} = require('./gateway/make-resolver')
-const { MER_ERR_GQL_GATEWAY_REFRESH, MER_ERR_GQL_GATEWAY_INIT, MER_ERR_SERVICE_RETRY_FAILED } = require('./errors')
-const findValueTypes = require('./gateway/find-value-types')
-const getQueryResult = require('./gateway/get-query-result')
+} = require('./make-resolver')
+const { MER_ERR_GQL_GATEWAY_REFRESH, MER_ERR_GQL_GATEWAY_INIT, MER_ERR_SERVICE_RETRY_FAILED } = require('../errors')
+const findValueTypes = require('./find-value-types')
+const getQueryResult = require('./get-query-result')
 
 function isDefaultType (type) {
   return [

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint:standard": "standard | snazzy",
     "lint:typescript": "standard --parser @typescript-eslint/parser --plugin @typescript-eslint/eslint-plugin test/types/*.ts",
     "typescript": "tsd",
-    "test": "npm run lint && npm run unit && npm run typescript"
+    "test": "npm run lint && npm run unit && npm run typescript",
+    "test2": "npm run unit"
   },
   "repository": {
     "type": "git",

--- a/test/gateway/config.js
+++ b/test/gateway/config.js
@@ -26,6 +26,36 @@ test('"schema" option not allowed in gateway mode', async (t) => {
   }
 })
 
+test('Throws an Error if the service list is empty', async (t) => {
+  const app = Fastify()
+
+  app.register(GQL, {
+    gateway: {
+      services: []
+    }
+  })
+
+  try {
+    await app.ready()
+  } catch (err) {
+    t.equal(err.message, 'Gateway schema init issues No valid service SDLs were provided')
+  }
+})
+
+test('Throws an Error if the service list is empty', async (t) => {
+  const app = Fastify()
+
+  app.register(GQL, {
+    gateway: {}
+  })
+
+  try {
+    await app.ready()
+  } catch (err) {
+    t.equal(err.message, 'Gateway schema init issues The "services" attribute cannot be undefined')
+  }
+})
+
 test('"resolvers" option not allowed in gateway mode', async (t) => {
   const app = Fastify()
 


### PR DESCRIPTION
Cleanup of the index file.

the stuff related to the gateway are moved in a separate file and the initialization is done with:

```
  let gateway
  let lruGatewayResolvers
  if (opts.gateway) {
    lruGatewayResolvers = buildCache(opts)
    gateway = await initGateway(opts, fastifyGraphQl, app)

    schema = gateway.schema
  }
```

Further improvement are required but this is the first step required for the gateway extraction.

@simoneb @mcollina 