### PR TITLE
Use the real Request object in subscriptions

### DIFF
--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -5,6 +5,7 @@
 - [Subscriptions](#subscriptions)
   - [Subscription support (simple)](#subscription-support-simple)
   - [Subscription filters](#subscription-filters)
+  - [Subscription Context](#subscription-context)
   - [Build a custom GraphQL context object for subscriptions](#build-a-custom-graphql-context-object-for-subscriptions)
   - [Subscription support (with redis)](#subscription-support-with-redis)
   - [Subscriptions with custom PubSub](#subscriptions-with-custom-pubsub)
@@ -152,6 +153,18 @@ app.register(mercurius, {
   subscription: true
 })
 ```
+
+### Subscription Context
+
+The context for the `Subscription` includes:
+
+* `app`, the Fastify application
+* `reply`, an object that pretend to be a `Reply` object from Fastify without its decorators.
+* `reply.request`, the real request object from Fastify
+
+During the connection initialization phase, all content of proerty `payload` of the `connection_init` packet
+is automatically copied inside `request.headers`. In case an `headers` property is specified within `payload`,
+that's used instead.
 
 ### Build a custom GraphQL context object for subscriptions
 

--- a/lib/subscription-connection.js
+++ b/lib/subscription-connection.js
@@ -159,8 +159,12 @@ module.exports = class SubscriptionConnection {
 
     this.context._connectionInit = data.payload
 
-    if (data.payload && data.payload.headers) {
-      this.headers = data.payload.headers
+    if (data.payload) {
+      if (data.payload.headers) {
+        this.headers = data.payload.headers
+      } else {
+        this.headers = data.payload
+      }
     }
 
     this.sendMessage(this.protocolMessageTypes.GQL_CONNECTION_ACK)
@@ -257,6 +261,13 @@ module.exports = class SubscriptionConnection {
       subscriptionLoaders = this.fastify[kSubscriptionFactory]
     }
 
+    for (const [key, value] of Object.entries(this.headers)) {
+      // as a security mechanism, do not override existing headers
+      if (context.request.headers[key] === undefined) {
+        context.request.headers[key] = value
+      }
+    }
+
     const subIter = await subscribe({
       schema,
       document,
@@ -270,7 +281,7 @@ module.exports = class SubscriptionConnection {
         lruGatewayResolvers: this.lruGatewayResolvers,
         reply: {
           entityResolversFactory: this.entityResolversFactory,
-          request: { headers: this.headers },
+          request: context.request,
           [kLoaders]:
             subscriptionLoaders && subscriptionLoaders.create(context),
           [kEntityResolvers]: this.entityResolvers

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -22,7 +22,8 @@ function createConnectionHandler ({ subscriber, fastify, onConnect, onDisconnect
 
     let context = {
       app: fastify,
-      pubsub: subscriber
+      pubsub: subscriber,
+      request
     }
 
     if (context.app.graphql && context.app.graphql[kHooks]) {


### PR DESCRIPTION
Signed-off-by: Matteo Collina <hello@matteocollina.com>

This PR does a few things:

1. uses the real `Request` object in the subscription `Context`. Reply is still "faked" as there is no `Reply` for websockets.
2. copies over all the data incoming as part of `connection_init` packet to `req.headers`. If there is a `headers` object that's used instead (as it was before). This change was needed because GraphiQL treats all the payload as headers.
