### PR TITLE
Add space between merged SDLs to fix merging errors

### DIFF
--- a/lib/gateway/build-gateway.js
+++ b/lib/gateway/build-gateway.js
@@ -313,7 +313,7 @@ async function buildGateway (gatewayOpts, app) {
     throw new MER_ERR_GQL_GATEWAY_INIT('No valid service SDLs were provided')
   }
 
-  const schema = buildFederatedSchema(serviceSDLs.join(''), true)
+  const schema = buildFederatedSchema(serviceSDLs.join(' '), true)
 
   const typeToServiceMap = {}
   const typeFieldsToService = {}
@@ -419,7 +419,7 @@ async function buildGateway (gatewayOpts, app) {
     async refresh (isRetry) {
       const failedMandatoryServices = []
       if (this._serviceSDLs === undefined) {
-        this._serviceSDLs = serviceSDLs.join('')
+        this._serviceSDLs = serviceSDLs.join(' ')
       }
 
       const $refreshResult = await Promise.allSettled(
@@ -458,7 +458,7 @@ async function buildGateway (gatewayOpts, app) {
 
       const _serviceSDLs = Object.values(serviceMap)
         .map((service) => service.schemaDefinition)
-        .join('')
+        .join(' ')
 
       if (this._serviceSDLs === _serviceSDLs) {
         return null


### PR DESCRIPTION
While using external graphs, they often (if not always) don't have any space around SDL, so while joining the strings, without adding any additional space, create unexpected keywords and throw errors while trying to parse the schema.