### PR TITLE
Prevent parsing schema exceptions when importing directives 

### DIFF
--- a/lib/federation.js
+++ b/lib/federation.js
@@ -92,7 +92,7 @@ function getStubTypes (schemaDefinitions, isGateway) {
   const directiveDefinitions = []
 
   for (const definition of schemaDefinitions) {
-    if (definition.kind === 'SchemaDefinition') {
+    if (definition.kind === 'SchemaDefinition' || definition.kind === 'SchemaExtension') {
       continue
     }
 


### PR DESCRIPTION
This fix prevents the app from breaking if schema contains [directives imports](https://www.apollographql.com/docs/federation/federated-types/federated-directives/#importing-directives) like this:

```gql
extend schema
  @link(url: "https://specs.apollo.dev/federation/v2.0",
        import: ["@key", "@shareable"])
```

I'm not sure if those imports actually work with Mercurius, but are a valid syntax, so shouldn't break it.