### PR TITLE
Explicitly say in the docs that JIT is disabled by default

### DIFF
--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -52,6 +52,7 @@
 
 - `jit`: Integer. The minimum number of execution a query needs to be
   executed before being jit'ed.
+  - Default: `0`, jit is disabled.
 - `routes`: boolean. Serves the Default: `true`. A graphql endpoint is
   exposed at `/graphql`.
 - `path`: string. Change default graphql `/graphql` route to another one.


### PR DESCRIPTION
I think that's a good thing to mention that JIT is disabled by default and should be explicitly enabled to get the performance benefits. I personally thought that it's enabled by default, but then I started digging into Mercurius and found how JIT is actually used there, and that it's not enabled by default.

Screenshot of the updated docs:
<img width="777" alt="Screenshot 2022-10-29 at 21 21 04" src="https://user-images.githubusercontent.com/36277508/198851065-c76264d1-5ea8-4faa-887f-32e94a415b2d.png">
