### PR TITLE
feat: add types for object in graphiql configuration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -437,12 +437,40 @@ export interface MercuriusSchemaOptions {
   schemaTransforms?: ((originalSchema: GraphQLSchema) => GraphQLSchema) | Array<(originalSchema: GraphQLSchema) => GraphQLSchema>;
 }
 
+export interface MercuriusGraphiQLOptions {
+  /**
+   * Expose the graphiql app, default `true`
+   */
+  enabled?: boolean;
+  /**
+   * The list of plugin to add to GraphiQL
+   */
+  plugins?: Array<{
+    /**
+     * The name of the plugin, it should be the same exported in the `umd`
+     */
+    name: string;
+    /**
+     * The props to be passed to the plugin
+     */
+    props?: Object;
+    /**
+     * The urls of the plugin, it's downloaded at runtime. (eg. https://unpkg.com/myplugin/....)
+     */
+    umdUrl: string;
+    /**
+     * A function name exported by the plugin to read/enrich the fetch response
+     */
+    fetcherWrapper?: string;
+  }>
+}
+
 export interface MercuriusCommonOptions {
   /**
    * Serve GraphiQL on /graphiql if true or 'graphiql' and if routes is true
    */
-  graphiql?: boolean | 'graphiql';
-  ide?: boolean | 'graphiql';
+  graphiql?: boolean | 'graphiql' | MercuriusGraphiQLOptions;
+  ide?: boolean | 'graphiql' | MercuriusGraphiQLOptions;
   /**
    * The minimum number of execution a query needs to be executed before being jit'ed.
    * @default 0 - disabled

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -879,3 +879,40 @@ app.graphql.addHook('onResolution', async function (_execution, context) {
   expectType<number | undefined>(context.operationsCount)
   expectType<string>(context.__currentQuery)
 })
+
+// Test graphiql configuration using an object as params
+app.register(mercurius, { schema, resolvers, graphiql: { plugins: [] } })
+
+app.register(mercurius, { schema, resolvers, ide: { enabled: false } })
+
+app.register(mercurius, {
+  schema,
+  resolvers,
+  graphiql: {
+    enabled: true,
+    plugins: [
+      {
+        fetcherWrapper: 'testFetchWrapper',
+        umdUrl: 'http://some-url',
+        props: { foo: 'bar' },
+        name: 'pluginName'
+      }
+    ]
+  }
+})
+
+expectError(() => {
+  app.register(mercurius, {
+    schema,
+    resolvers,
+    graphiql: {
+      enabled: true,
+      plugins: [
+        {
+          fetcherWrapper: 'testFetchWrapper',
+          props: { foo: 'bar' }
+        }
+      ]
+    }
+  })
+})


### PR DESCRIPTION
Adds the type definition for the configuration of graphiql using an object.