### PR TITLE
fix/ws-error-handler - Update fastify/websocket to 7.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@fastify/error": "^3.0.0",
     "@fastify/static": "^6.0.0",
-    "@fastify/websocket": "^7.0.0",
+    "@fastify/websocket": "^7.1.1",
     "events.on": "^1.0.1",
     "fastify-plugin": "^4.2.0",
     "graphql": "^16.0.0",


### PR DESCRIPTION
This update fix #908.