### PR TITLE
feat: adds graphql resolve info to loader ts definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -48,6 +48,7 @@ export interface Loader<
     queries: Array<{
       obj: TObj;
       params: TParams;
+      info?: GraphQLResolveInfo;
     }>,
     context: TContext & {
       reply: FastifyReply;


### PR DESCRIPTION
Adds info object into loader definition, as a loader with disabled caching will provide the info object