### PR TITLE
feat: Allow preExecution hook to modify variables

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -62,17 +62,24 @@ fastify.graphql.addHook('preValidation', async (schema, document, context) => {
 In the `preExecution` hook, you can modify the following items by returning them in the hook definition:
   - `document`
   - `schema`
+  - `variables`
   - `errors`
 
 Note that if you modify the `schema` or the `document` object, the [jit](./api/options.md#plugin-options) compilation will be disabled for the request.
 
 ```js
-fastify.graphql.addHook('preExecution', async (schema, document, context) => {
-  const { modifiedSchema, modifiedDocument, errors } = await asyncMethod(document)
+fastify.graphql.addHook('preExecution', async (schema, document, context, variables) => {
+  const {
+    modifiedSchema,
+    modifiedDocument,
+    modifiedVariables,
+    errors
+  } = await asyncMethod(document)
 
   return {
     schema: modifiedSchema, // ⚠️ changing the schema may break the query execution. Use it carefully.
     document: modifiedDocument,
+    variables: modifiedVariables,
     errors
   }
 })

--- a/index.d.ts
+++ b/index.d.ts
@@ -104,14 +104,17 @@ export interface preValidationHookHandler<TContext = MercuriusContext> {
 /**
  * `preExecution` is the third hook to be executed in the GraphQL request lifecycle. The previous hook was `preValidation`, the next hook will be `preGatewayExecution`.
  * Notice: in the `preExecution` hook, you can modify the following items by returning them in the hook definition:
+ *  - `schema`
  *  - `document`
  *  - `errors`
+ *  - `variables`
  */
 export interface preExecutionHookHandler<TContext = MercuriusContext, TError extends Error = Error> {
   (
     schema: GraphQLSchema,
     source: DocumentNode,
     context: TContext,
+    variables: Record<string, any>,
   ): Promise<PreExecutionHookResponse<TError> | void> | PreExecutionHookResponse<TError> | void;
 }
 
@@ -831,5 +834,6 @@ type ValidationRules =
 export interface PreExecutionHookResponse<TError extends Error> {
   schema?: GraphQLSchema
   document?: DocumentNode
-  errors?: TError[]
+  errors?: TError[],
+  variables?: Record<string, any>,
 }

--- a/index.js
+++ b/index.js
@@ -522,11 +522,13 @@ const plugin = fp(async function (app, opts) {
     // Trigger preExecution hook
     let modifiedSchema
     let modifiedDocument
+    let modifiedVariables
     if (context.preExecution !== null) {
-      ({ modifiedSchema, modifiedDocument } = await preExecutionHandler({
+      ({ modifiedSchema, modifiedDocument, modifiedVariables } = await preExecutionHandler({
         schema: fastifyGraphQl.schema,
         document,
-        context
+        context,
+        variables
       }))
     }
 
@@ -542,7 +544,7 @@ const plugin = fp(async function (app, opts) {
     }
 
     if (cached && cached.jit !== null && !modifiedSchema && !modifiedDocument && isCompiledQuery(cached.jit)) {
-      const execution = await cached.jit.query(root, context, variables || {})
+      const execution = await cached.jit.query(root, context, modifiedVariables || variables || {})
       return maybeFormatErrors(execution, context)
     }
 
@@ -551,7 +553,7 @@ const plugin = fp(async function (app, opts) {
       document: modifiedDocument || document,
       rootValue: root,
       contextValue: context,
-      variableValues: variables,
+      variableValues: modifiedVariables || variables,
       operationName
     })
 

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -29,17 +29,28 @@ async function preValidationHandler (request) {
 }
 
 async function preExecutionHandler (request) {
-  const { errors, modifiedDocument, modifiedSchema } = await preExecutionHooksRunner(
+  const {
+    errors,
+    modifiedDocument,
+    modifiedSchema,
+    modifiedVariables
+  } = await preExecutionHooksRunner(
     request.context.preExecution,
     request
   )
+
   if (errors.length > 0) {
     addErrorsToContext(request.context, errors)
   }
-  if (typeof modifiedDocument !== 'undefined' || typeof modifiedSchema !== 'undefined') {
+  if (
+    typeof modifiedDocument !== 'undefined' ||
+    typeof modifiedSchema !== 'undefined' ||
+    typeof modifiedVariables !== 'undefined'
+  ) {
     return Object.create(null, {
       modifiedDocument: { value: modifiedDocument },
-      modifiedSchema: { value: modifiedSchema }
+      modifiedSchema: { value: modifiedSchema },
+      modifiedVariables: { value: modifiedVariables }
     })
   }
 

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -89,11 +89,14 @@ async function preExecutionHooksRunner (functions, request) {
   let errors = []
   let modifiedSchema
   let modifiedDocument
+  let modifiedVariables
 
   for (const fn of functions) {
-    const result = await fn(modifiedSchema || request.schema,
+    const result = await fn(
+      modifiedSchema || request.schema,
       modifiedDocument || request.document,
-      request.context
+      request.context,
+      modifiedVariables || request.variables
     )
 
     if (result) {
@@ -103,13 +106,16 @@ async function preExecutionHooksRunner (functions, request) {
       if (typeof result.document !== 'undefined') {
         modifiedDocument = result.document
       }
+      if (typeof result.variables !== 'undefined') {
+        modifiedVariables = result.variables
+      }
       if (typeof result.errors !== 'undefined') {
         errors = errors.concat(result.errors)
       }
     }
   }
 
-  return { errors, modifiedDocument, modifiedSchema }
+  return { errors, modifiedDocument, modifiedSchema, modifiedVariables }
 }
 
 async function preGatewayExecutionHooksRunner (functions, request) {

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -691,36 +691,41 @@ app.graphql.addHook('preValidation', function (schema, document, context) {
   expectAssignable<MercuriusContext>(context)
 })
 
-app.graphql.addHook('preExecution', async function (schema, document, context) {
+app.graphql.addHook('preExecution', async function (schema, document, context, variables) {
   expectAssignable<GraphQLSchema>(schema)
   expectAssignable<DocumentNode>(document)
   expectAssignable<MercuriusContext>(context)
+  expectAssignable<Record<string, any>>(context)
   return {
     schema,
     document,
+    variables,
     errors: [
       new Error('foo')
     ]
   }
 })
 
-app.graphql.addHook('preExecution', function (schema, document, context) {
+app.graphql.addHook('preExecution', function (schema, document, context, variables) {
   expectAssignable<GraphQLSchema>(schema)
   expectAssignable<DocumentNode>(document)
   expectAssignable<MercuriusContext>(context)
+  expectAssignable<Record<string, any>>(context)
   return {
     schema,
     document,
+    variables,
     errors: [
       new Error('foo')
     ]
   }
 })
 
-app.graphql.addHook('preExecution', function (schema, document, context) {
+app.graphql.addHook('preExecution', function (schema, document, context, variables) {
   expectAssignable<GraphQLSchema>(schema)
   expectAssignable<DocumentNode>(document)
   expectAssignable<MercuriusContext>(context)
+  expectAssignable<Record<string, any>>(context)
 })
 
 app.graphql.addHook('preGatewayExecution', async function (schema, document, context) {


### PR DESCRIPTION
I saw discussions about this on https://github.com/mercurius-js/mercurius/issues/876, which mainly talked about **accessing** variables, but there is a comment that also mentions updating them.

I require this use-case, where hooks can modify the incoming variables based on logic or contacting external systems. See the test included with the PR for an example. 

This could have be achieved by putting the logic in a plugin earlier in the chain than Mercurius, but preventing double query parsing would be difficult, as the hooks need to be query-aware. 

I'll admit I don't have a complete understanding of this codebase so forgive me if there are any things I've missed here, it's mainly to frame the requirement I have and start a discussion. 

If there is any modifications you'd like here, let me know and I'd be happy to contribute; I can update any documentation as necessary, but wanted to wait until this feature was discussed. 