### PR TITLE
refactor: removed events.on and use native api

### DIFF
--- a/lib/subscription-connection.js
+++ b/lib/subscription-connection.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const on = require('events.on')
+const { on } = require('events')
 const { subscribe, parse, print, getOperationAST } = require('graphql')
 const { SubscriptionContext } = require('./subscriber')
 const { kEntityResolvers } = require('./gateway/make-resolver')

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "@fastify/error": "^3.0.0",
     "@fastify/static": "^6.0.0",
     "@fastify/websocket": "^7.0.0",
-    "events.on": "^1.0.1",
     "fastify-plugin": "^4.2.0",
     "graphql": "^16.0.0",
     "graphql-jit": "^0.7.3",


### PR DESCRIPTION
from issue https://github.com/mercurius-js/mercurius/issues/725.
events.on is native on node since added in: v13.6.0, v12.16.0 so I think there is no reason to keep this polyfill for 10.x