### PR TITLE
feat: ast input support added

### DIFF
--- a/index.js
+++ b/index.js
@@ -444,9 +444,14 @@ const plugin = fp(async function (app, opts) {
       try {
         document = parse(source)
       } catch (syntaxError) {
-        const err = new MER_ERR_GQL_VALIDATION()
-        err.errors = [syntaxError]
-        throw err
+        try {
+          // Try to parse the source as ast
+          document = JSON.parse(source)
+        } catch {
+          const err = new MER_ERR_GQL_VALIDATION()
+          err.errors = [syntaxError]
+          throw err
+        }
       }
 
       // Trigger preValidation hook

--- a/test/app-decorator.js
+++ b/test/app-decorator.js
@@ -1356,3 +1356,84 @@ test('throws on invalid ast input', async (t) => {
     t.equal(err.name, 'Error')
   }
 })
+
+test('support ast input on external requests', async (t) => {
+  const app = Fastify()
+  const schema = `
+    type Query {
+      add(x: Int, y: Int): Int
+    }
+  `
+
+  const resolvers = {
+    add: async ({ x, y }) => x + y
+  }
+
+  app.register(GQL, {
+    schema,
+    resolvers
+  })
+
+  // needed so that graphql is defined
+  await app.ready()
+
+  const query = `{
+    "kind": "Document",
+    "definitions": [
+      {
+        "kind": "OperationDefinition",
+        "operation": "query",
+        "variableDefinitions": [],
+        "directives": [],
+        "selectionSet": {
+          "kind": "SelectionSet",
+          "selections": [
+            {
+              "kind": "Field",
+              "name": {
+                "kind": "Name",
+                "value": "add"
+              },
+              "arguments": [
+                {
+                  "kind": "Argument",
+                  "name": {
+                    "kind": "Name",
+                    "value": "x"
+                  },
+                  "value": {
+                    "kind": "IntValue",
+                    "value": "2"
+                  }
+                },
+                {
+                  "kind": "Argument",
+                  "name": {
+                    "kind": "Name",
+                    "value": "y"
+                  },
+                  "value": {
+                    "kind": "IntValue",
+                    "value": "2"
+                  }
+                }
+              ],
+              "directives": []
+            }
+          ]
+        }
+      }
+    ]
+  }`
+  const res = await app.inject({
+    method: 'POST',
+    url: '/graphql',
+    body: { query }
+  })
+
+  t.same(JSON.parse(res.body), {
+    data: {
+      add: 4
+    }
+  })
+})

--- a/test/app-decorator.js
+++ b/test/app-decorator.js
@@ -1203,3 +1203,84 @@ test('calling extendSchema throws an error if federationMetadata is enabled', as
     t.end()
   }
 })
+
+test('support ast input', async (t) => {
+  const app = Fastify()
+  const schema = `
+    type Query {
+      add(x: Int, y: Int): Int
+    }
+  `
+
+  const resolvers = {
+    add: async ({ x, y }) => x + y
+  }
+
+  app.register(GQL, {
+    schema,
+    resolvers
+  })
+
+  // needed so that graphql is defined
+  await app.ready()
+
+  const query = `{
+    "kind": "Document",
+    "definitions": [
+      {
+        "kind": "OperationDefinition",
+        "operation": "query",
+        "variableDefinitions": [],
+        "directives": [],
+        "selectionSet": {
+          "kind": "SelectionSet",
+          "selections": [
+            {
+              "kind": "Field",
+              "name": {
+                "kind": "Name",
+                "value": "add"
+              },
+              "arguments": [
+                {
+                  "kind": "Argument",
+                  "name": {
+                    "kind": "Name",
+                    "value": "x"
+                  },
+                  "value": {
+                    "kind": "IntValue",
+                    "value": "2"
+                  }
+                },
+                {
+                  "kind": "Argument",
+                  "name": {
+                    "kind": "Name",
+                    "value": "y"
+                  },
+                  "value": {
+                    "kind": "IntValue",
+                    "value": "2"
+                  }
+                }
+              ],
+              "directives": []
+            }
+          ]
+        }
+      }
+    ],
+    "loc": {
+      "start": 0,
+      "end": 19
+    }
+  }`
+  const res = await app.graphql(query)
+
+  t.same(res, {
+    data: {
+      add: 4
+    }
+  })
+})


### PR DESCRIPTION
closes #804 

JSON ast can be now used as input.

The change can be tested with the code of the test added at test/app-decorator.js

Comments are welcomed for both performance and security on the use of `JSON.parse` function

It should be decided whether this feature is desired.