### PR TITLE
Update to @fastify/websocket v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "autocannon": "^7.3.0",
     "concurrently": "^8.0.1",
     "docsify-cli": "^4.4.3",
-    "fastify": "^4.0.0",
+    "fastify": "^4.16.0",
     "graphql-ws": "^5.11.2",
     "pre-commit": "^1.2.2",
     "proxyquire": "^2.1.3",
@@ -58,7 +58,7 @@
   "dependencies": {
     "@fastify/error": "^3.0.0",
     "@fastify/static": "^6.0.0",
-    "@fastify/websocket": "^7.0.0",
+    "@fastify/websocket": "^8.0.0",
     "fastify-plugin": "^4.2.0",
     "graphql": "^16.0.0",
     "graphql-jit": "^0.8.0",


### PR DESCRIPTION
Updates to `@fastify/websocket` v8 to address a leak and crash in certain condition. This requires a minimum version of Fastify of v4.16.0 (just released), hence the major update.