### PR TITLE
Refactoring tests that check if an error has been thrown

### DIFF
--- a/test/app-decorator.js
+++ b/test/app-decorator.js
@@ -246,11 +246,8 @@ test('replaceSchema (clearing cache)', async (t) => {
   )
 
   query = '{ subtract(x: 4, y: 2) }'
-  try {
-    await app.graphql(query)
-  } catch (err) {
-    t.equal(err.errors[0].message, 'Cannot query field "subtract" on type "Query".')
-  }
+
+  await t.rejects(app.graphql(query), { errors: [{ message: 'Cannot query field "subtract" on type "Query".' }] })
 })
 
 test('replaceSchema (without cache)', async (t) => {
@@ -304,11 +301,8 @@ test('replaceSchema (without cache)', async (t) => {
   )
 
   query = '{ subtract(x: 4, y: 2) }'
-  try {
-    await app.graphql(query)
-  } catch (err) {
-    t.equal(err.errors[0].message, 'Cannot query field "subtract" on type "Query".')
-  }
+
+  await t.rejects(app.graphql(query), { errors: [{ message: 'Cannot query field "subtract" on type "Query".' }] })
 })
 
 test('replaceSchema with makeSchemaExecutable (schema should be provided)', async (t) => {
@@ -333,11 +327,7 @@ test('replaceSchema with makeSchemaExecutable (schema should be provided)', asyn
     app.graphql.replaceSchema()
   })
 
-  try {
-    await app.ready()
-  } catch (error) {
-    t.equal(error.message, 'Invalid options: Must provide valid Document AST')
-  }
+  await t.rejects(app.ready(), 'Invalid options: Must provide valid Document AST')
 })
 
 test('extendSchema and defineResolvers for query', async (t) => {
@@ -1003,11 +993,7 @@ test('extended Schema is not string', async t => {
     app.graphql.extendSchema(schema2)
   })
 
-  try {
-    await app.ready()
-  } catch (error) {
-    t.equal(error.message, 'Invalid options: Must provide valid Document AST')
-  }
+  await t.rejects(app.ready(), { message: 'Invalid options: Must provide valid Document AST' })
 })
 
 test('extended Schema is undefined', async t => {
@@ -1022,11 +1008,7 @@ test('extended Schema is undefined', async t => {
     app.graphql.extendSchema()
   })
 
-  try {
-    await app.ready()
-  } catch (error) {
-    t.equal(error.message, 'Invalid options: Must provide valid Document AST')
-  }
+  await t.rejects(app.ready(), { message: 'Invalid options: Must provide valid Document AST' })
 })
 
 test('extended Schema is an object', async t => {
@@ -1095,16 +1077,14 @@ test('Error in schema', async (t) => {
 
   const app = Fastify()
 
-  try {
-    app.register(GQL, {
-      schema,
-      resolvers
-    })
-    await app.ready()
-  } catch (error) {
-    t.equal(error.message, 'Interface field Event.Id expected but CustomEvent does not provide it.')
-    t.equal(error.name, 'GraphQLError')
-  }
+  app.register(GQL, {
+    schema,
+    resolvers
+  })
+  await t.rejects(app.ready(), {
+    message: 'Interface field Event.Id expected but CustomEvent does not provide it.',
+    name: 'GraphQLError'
+  })
 })
 
 test('Multiple errors in schema', async (t) => {
@@ -1131,20 +1111,24 @@ test('Multiple errors in schema', async (t) => {
 
   const app = Fastify()
 
-  try {
-    app.register(GQL, {
-      schema,
-      resolvers
-    })
-    await app.ready()
-  } catch (error) {
-    t.equal(error.message, 'Invalid schema: check out the .errors property on the Error')
-    t.equal(error.name, 'FastifyError')
-    t.equal(error.errors[0].message, 'Interface field Event.Id expected but CustomEvent does not provide it.')
-    t.equal(error.errors[0].name, 'GraphQLError')
-    t.equal(error.errors[1].message, 'Interface field Event.Id expected but AnotherEvent does not provide it.')
-    t.equal(error.errors[1].name, 'GraphQLError')
-  }
+  app.register(GQL, {
+    schema,
+    resolvers
+  })
+  await t.rejects(app.ready(), {
+    message: 'Invalid schema: check out the .errors property on the Error',
+    name: 'FastifyError',
+    errors: [
+      {
+        message: 'Interface field Event.Id expected but CustomEvent does not provide it.',
+        name: 'GraphQLError'
+      },
+      {
+        message: 'Interface field Event.Id expected but AnotherEvent does not provide it.',
+        name: 'GraphQLError'
+      }
+    ]
+  })
 })
 
 test('defineResolvers should throw if field is not defined in schema', async (t) => {
@@ -1319,12 +1303,10 @@ test('throws on invalid ast input', async (t) => {
       }
     ]
   }`
-  try {
-    await app.graphql(query)
-  } catch (err) {
-    t.equal(err.message, 'Invalid AST Node: { definitions: [[Object]] }.')
-    t.equal(err.name, 'Error')
-  }
+  await t.rejects(app.graphql(query), {
+    message: 'Invalid AST Node: { definitions: [[Object]] }.',
+    name: 'Error'
+  })
 })
 
 test('support ast input on external requests', async (t) => {

--- a/test/disable-instrospection.js
+++ b/test/disable-instrospection.js
@@ -34,13 +34,7 @@ test('should disallow instrospection with "__schema" when NoSchemaIntrospectionC
 
   // needed so that graphql is defined
   await app.ready()
-
-  try {
-    await app.graphql(query)
-  } catch (e) {
-    t.equal(e.errors.length > 0, true)
-    t.equal(e.errors[0].message, 'GraphQL introspection has been disabled, but the requested query contained the field "__schema".')
-  }
+  await t.rejects(app.graphql(query), { errors: [{ message: 'GraphQL introspection has been disabled, but the requested query contained the field "__schema".' }] })
 })
 
 test('should disallow instrospection with "__type" when NoSchemaIntrospectionCustomRule are applied to validationRules', async (t) => {
@@ -57,11 +51,5 @@ test('should disallow instrospection with "__type" when NoSchemaIntrospectionCus
 
   // needed so that graphql is defined
   await app.ready()
-
-  try {
-    await app.graphql(query)
-  } catch (e) {
-    t.equal(e.errors.length > 0, true)
-    t.equal(e.errors[0].message, 'GraphQL introspection has been disabled, but the requested query contained the field "__type".')
-  }
+  await t.rejects(app.graphql(query), { errors: [{ message: 'GraphQL introspection has been disabled, but the requested query contained the field "__type".' }] })
 })

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -126,38 +126,24 @@ test('hooks can be called multiple times', async t => {
 })
 
 test('hooks validation should handle invalid hook names', async t => {
-  t.plan(1)
   const app = await createTestServer(t)
-
-  try {
-    app.graphql.addHook('unsupportedHook', async () => {})
-  } catch (e) {
-    t.equal(e.message, 'unsupportedHook hook not supported!')
-  }
+  t.rejects(async () => app.graphql.addHook('unsupportedHook', async () => {}), { message: 'unsupportedHook hook not supported!' })
 })
 
 test('hooks validation should handle invalid hook name types', async t => {
-  t.plan(2)
   const app = await createTestServer(t)
-
-  try {
-    app.graphql.addHook(1, async () => {})
-  } catch (e) {
-    t.equal(e.code, 'MER_ERR_HOOK_INVALID_TYPE')
-    t.equal(e.message, 'The hook name must be a string')
-  }
+  t.rejects(async () => app.graphql.addHook(1, async () => {}), {
+    code: 'MER_ERR_HOOK_INVALID_TYPE',
+    message: 'The hook name must be a string'
+  })
 })
 
 test('hooks validation should handle invalid hook handlers', async t => {
-  t.plan(2)
   const app = await createTestServer(t)
-
-  try {
-    app.graphql.addHook('preParsing', 'not a function')
-  } catch (e) {
-    t.equal(e.code, 'MER_ERR_HOOK_INVALID_HANDLER')
-    t.equal(e.message, 'The hook callback must be a function')
-  }
+  t.rejects(async () => app.graphql.addHook('preParsing', 'not a function'), {
+    code: 'MER_ERR_HOOK_INVALID_HANDLER',
+    message: 'The hook callback must be a function'
+  })
 })
 
 test('hooks should trigger when JIT is enabled', async t => {

--- a/test/internals/hooksRunner.js
+++ b/test/internals/hooksRunner.js
@@ -31,11 +31,7 @@ test('hooksRunner - Basic', (t) => {
 test('hooksRunner - In case of error should skip subsequent functions', async (t) => {
   t.plan(3)
 
-  try {
-    await hooksRunner([fn1, fn2, fn3], iterator, 'a')
-  } catch (err) {
-    t.equal(err.message, 'kaboom')
-  }
+  await t.rejects(hooksRunner([fn1, fn2, fn3], iterator, 'a'), { message: 'kaboom' })
 
   function iterator (fn, a) {
     return fn(a)
@@ -118,13 +114,7 @@ test('hooksRunner - Promises that resolve to a value do not change the state', (
 })
 
 test('hooksRunner - Should handle when iterator errors', async (t) => {
-  t.plan(1)
-
-  try {
-    await hooksRunner([fn1, fn2], iterator, 'a')
-  } catch (err) {
-    t.equal(err.message, 'kaboom')
-  }
+  await t.rejects(hooksRunner([fn1, fn2], iterator, 'a'), { message: 'kaboom' })
 
   function iterator (fn) {
     throw new Error('kaboom')
@@ -172,12 +162,7 @@ test('preExecutionHooksRunner - In case of error should skip subsequent function
   t.plan(7)
 
   const originalRequest = { schema: 'schema', document: 'document', context: 'context' }
-
-  try {
-    await preExecutionHooksRunner([fn1, fn2, fn3], originalRequest)
-  } catch (err) {
-    t.equal(err.message, 'kaboom')
-  }
+  await t.rejects(preExecutionHooksRunner([fn1, fn2, fn3], originalRequest), { message: 'kaboom' })
 
   function fn1 (schema, document, context) {
     t.equal(schema, 'schema')
@@ -269,13 +254,8 @@ test('preExecutionHooksRunner - Should handle thrown errors', async t => {
   t.plan(8)
 
   const originalRequest = { schema: 'schema', document: 'document', context: 'context' }
-
-  try {
-    await preExecutionHooksRunner([fn1, fn2, fn3], originalRequest)
-  } catch (err) {
-    t.equal(err.message, 'kaboom')
-    t.same(originalRequest, { schema: 'schema', document: 'document', context: 'context' })
-  }
+  await t.rejects(preExecutionHooksRunner([fn1, fn2, fn3], originalRequest), { message: 'kaboom' })
+  t.same(originalRequest, { schema: 'schema', document: 'document', context: 'context' })
 
   function fn1 (schema, document, context) {
     t.equal(schema, 'schema')

--- a/test/loaders.js
+++ b/test/loaders.js
@@ -448,13 +448,10 @@ test('rersolver unknown type', async t => {
     resolvers
   })
 
-  try {
-    // needed so that graphql is defined
+  await t.rejects(async () => {
     await app.ready()
     app.graphql('query { test }')
-  } catch (error) {
-    t.equal(error.message, 'Invalid options: Cannot find type test')
-  }
+  }, { message: 'Invalid options: Cannot find type test' })
 })
 
 test('minJit is not a number, throw error', async t => {
@@ -464,11 +461,7 @@ test('minJit is not a number, throw error', async t => {
     jit: '0'
   })
 
-  try {
-    await app.ready()
-  } catch (error) {
-    t.equal(error.message, 'Invalid options: the jit option must be a number')
-  }
+  await t.rejects(app.ready(), { message: 'Invalid options: the jit option must be a number' })
 })
 
 test('options cache is type = number', async t => {
@@ -482,21 +475,6 @@ test('options cache is type = number', async t => {
   await app.ready()
 })
 
-test('options cache is boolean', async t => {
-  const app = Fastify()
-
-  app.register(GQL, {
-    cache: true,
-    schema
-  })
-
-  try {
-    await app.ready()
-  } catch (error) {
-    t.equal(error.message, 'Invalid options: Cache type is not supported')
-  }
-})
-
 test('options cache is !number && !boolean', async t => {
   const app = Fastify()
 
@@ -504,11 +482,7 @@ test('options cache is !number && !boolean', async t => {
     cache: 'cache'
   })
 
-  try {
-    await app.ready()
-  } catch (error) {
-    t.equal(error.message, 'Invalid options: Cache type is not supported')
-  }
+  await t.rejects(app.ready(), { message: 'Invalid options: Cache type is not supported' })
 })
 
 test('options cache is false and lruErrors exists', async t => {
@@ -521,13 +495,7 @@ test('options cache is false and lruErrors exists', async t => {
 
   // needed so that graphql is defined
   await app.ready()
-
-  try {
-    await app.graphql('{ dogs { name { owner } } }')
-  } catch (error) {
-    t.equal(error.message, 'Graphql validation error')
-    t.end()
-  }
+  await t.rejects(app.graphql('{ dogs { name { owner } } }'), { message: 'Graphql validation error' })
 })
 
 test('reply is empty, throw error', async (t) => {

--- a/test/query-depth.js
+++ b/test/query-depth.js
@@ -156,7 +156,6 @@ test('queryDepth - test total depth is within queryDepth parameter', async (t) =
 })
 
 test('queryDepth - test total depth is over queryDepth parameter', async (t) => {
-  t.plan(1)
   const app = Fastify()
 
   app.register(GQL, {
@@ -172,11 +171,7 @@ test('queryDepth - test total depth is over queryDepth parameter', async (t) => 
   const queryDepthError = new MER_ERR_GQL_QUERY_DEPTH('unnamedQuery', 6, 5)
   err.errors = [queryDepthError]
 
-  try {
-    await app.graphql(query)
-  } catch (error) {
-    t.same(error, err)
-  }
+  await t.rejects(app.graphql(query), err)
 })
 
 test('queryDepth - queryDepth is not number', async (t) => {

--- a/test/subscriber.js
+++ b/test/subscriber.js
@@ -67,7 +67,6 @@ test('subscription context publish event errs, error is catched', t => {
 })
 
 test('subscription context publish event returns a promise reject on error', async t => {
-  t.plan(1)
   const emitter = mq()
   const error = new Error('Dummy error')
   emitter.on = (topic, listener, done) => done(error)
@@ -75,11 +74,7 @@ test('subscription context publish event returns a promise reject on error', asy
   const pubsub = new PubSub(emitter)
   const sc = new SubscriptionContext({ pubsub })
 
-  try {
-    await sc.subscribe('TOPIC')
-  } catch (e) {
-    t.same(error, e)
-  }
+  await t.rejects(sc.subscribe('TOPIC'), error)
 })
 
 test('subscription context can handle multiple topics', t => {

--- a/test/validation-rules.js
+++ b/test/validation-rules.js
@@ -23,7 +23,6 @@ const resolvers = {
 const query = '{ add(x: 2, y: 2) }'
 
 test('validationRules array - reports an error', async (t) => {
-  t.plan(2)
   const app = Fastify()
 
   app.register(GQL, {
@@ -43,13 +42,7 @@ test('validationRules array - reports an error', async (t) => {
 
   // needed so that graphql is defined
   await app.ready()
-
-  try {
-    await app.graphql(query)
-  } catch (e) {
-    t.equal(e.errors.length, 1)
-    t.equal(e.errors[0].message, 'Validation rule error')
-  }
+  await t.rejects(app.graphql(query), { errors: [{ message: 'Validation rule error' }] })
 })
 
 test('validationRules array - passes when no errors', async (t) => {
@@ -96,7 +89,6 @@ test('validationRules array - works with empty validationRules', async (t) => {
 })
 
 test('validationRules - reports an error', async (t) => {
-  t.plan(2)
   const app = Fastify()
 
   app.register(GQL, {
@@ -117,13 +109,7 @@ test('validationRules - reports an error', async (t) => {
 
   // needed so that graphql is defined
   await app.ready()
-
-  try {
-    await app.graphql(query)
-  } catch (e) {
-    t.equal(e.errors.length, 1)
-    t.equal(e.errors[0].message, 'Validation rule error')
-  }
+  await t.rejects(app.graphql(query), { errors: [{ message: 'Validation rule error' }] })
 })
 
 test('validationRules - passes when no errors', async (t) => {
@@ -227,7 +213,6 @@ test('validationRules - includes graphql request metadata', async (t) => {
 })
 
 test('validationRules - errors if cache is used with the function', async (t) => {
-  t.plan(1)
   const app = Fastify()
 
   app.register(GQL, {
@@ -238,10 +223,5 @@ test('validationRules - errors if cache is used with the function', async (t) =>
   })
 
   // needed so that graphql is defined
-
-  try {
-    await app.ready()
-  } catch (e) {
-    t.equal(e.message, 'Invalid options: Using a function for the validationRules is incompatible with query caching')
-  }
+  await t.rejects(app.ready(), { message: 'Invalid options: Using a function for the validationRules is incompatible with query caching' })
 })


### PR DESCRIPTION
I refactored almost 30 tests that were using try/catch to check if an error had been thrown. There are two problems with this approach:
- It's unnecessarily complex. We can easily replace these try/catch-based assertions with `t.rejects`.   
- But the worst issue is: without using `t.plan()`, these tests would pass even if the error wasn't thrown. And most of these tests weren't using `t.plan`. In fact, 4 tests were passing without the exceptions they test for being thrown. Out of these 4, I was able to confirm that at least 1 was obsolete, so I've removed it. The other 3 tests remain untouched (`test/app-decorator.js:476`, `test/loaders:529` and `test/routes:964`).

closes #995 

FYI: @simoneb 