### PR TITLE
bugfix: handle if errors is not an array

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -46,7 +46,10 @@ function defaultErrorFormatter (execution, ctx) {
     // it handles fastify errors MER_ERR_GQL_VALIDATION
     if (error.originalError?.errors) {
       // not all errors are `GraphQLError` type, we need to convert them
-      return error.originalError.errors.map(toGraphQLError)
+      if(Array.isArray(error.originalError.errors)){
+        return error.originalError.errors.map(toGraphQLError)
+      }
+      return toGraphQLError(error.originalError.errors)
     }
 
     return error


### PR DESCRIPTION
closes #1024 

- check that `error.originalError.errors` is an array before mapping it.
- if not an array, but is defined, try to handle it anyway.