### PR TITLE
add meta tags for page previews

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,19 @@
   <head>
     <meta charset="UTF-8" />
     <title>Mercurius</title>
+    <meta name="title" content="Mercurius" />
+    <meta name="description" content="Mercurius is a GraphQL adapter for Fastify" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://mercurius.dev/" />
+    <meta property="og:title" content="Mercurius" />
+    <meta property="og:description" content="Mercurius is a GraphQL adapter for Fastify" />
+    <meta property="og:image" content="https://raw.githubusercontent.com/mercurius-js/graphics/main/mercurius-horizontal.png" />
+    <meta property="twitter:card" content="summary_large_image" />
+    <meta property="twitter:url" content="https://mercurius.dev/" />
+    <meta property="twitter:title" content="Mercurius" />
+    <meta property="twitter:description" content="Mercurius is a GraphQL adapter for Fastify" />
+    <meta property="twitter:image" content="https://raw.githubusercontent.com/mercurius-js/graphics/main/mercurius-horizontal.png" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-    <meta name="description" content="Description" />
     <meta
       name="viewport"
       content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"


### PR DESCRIPTION
This allows for https://mercurius.dev to offer a richer preview when shared in platforms like Discord or the usual social networks. 