### PR TITLE
Remove all listeners on close

### DIFF
--- a/lib/subscriber.js
+++ b/lib/subscriber.js
@@ -25,7 +25,8 @@ class PubSub {
 
         resolve()
       })
-      queue.close = close
+      if (!queue.close) queue.close = []
+      queue.close.push(close)
     })
   }
 
@@ -68,8 +69,8 @@ class SubscriptionContext {
   close () {
     // In rare cases when `subscribe()` not called (e.g. some network error)
     // `close` will be `undefined`.
-    if (typeof this.queue.close === 'function') {
-      this.queue.close()
+    if (Array.isArray(this.queue.close)) {
+      this.queue.close.map((close) => close())
     }
     this.queue.push(null)
   }

--- a/test/subscriber.js
+++ b/test/subscriber.js
@@ -78,9 +78,10 @@ test('subscription context publish event returns a promise reject on error', asy
 })
 
 test('subscription context can handle multiple topics', t => {
-  t.plan(2)
+  t.plan(4)
 
-  const pubsub = new PubSub(mq())
+  const q = mq()
+  const pubsub = new PubSub(q)
   const sc = new SubscriptionContext({ pubsub })
 
   sc.subscribe(['TOPIC1', 'TOPIC2'])
@@ -96,4 +97,8 @@ test('subscription context can handle multiple topics', t => {
   }).then(() => {
     t.pass()
   })
+
+  t.equal(q._matcher._trie.size, 2, 'Two listeners not found')
+  sc.close()
+  setImmediate(() => { t.equal(q._matcher._trie.size, 0, 'All listeners not removed') })
 })


### PR DESCRIPTION
This patch calls the removeListener on emitter for all subscribed topics. It is important to avoid memory leak.
When using MQEmitterRedis is most important to unsubscribe pattern on redis server.