### PR TITLE
make url dynamic so even if the graphiql is deployed on baseUrl it can work.

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -97,11 +97,16 @@ function fetcherWrapper (fetcher, cbs = []) {
 
 function render () {
   const host = window.location.host
-
   const websocketProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-
-  const url = `${window.location.protocol}//${host}${window.GRAPHQL_ENDPOINT}`
-  const subscriptionUrl = `${websocketProtocol}//${host}${window.GRAPHQL_ENDPOINT}`
+  let url = ''
+  let subscriptionUrl = ''
+  if (window.baseurl) {
+    url = `${window.location.protocol}//${host}${window.baseurl}${window.GRAPHQL_ENDPOINT}`
+    subscriptionUrl = `${websocketProtocol}//${host}${window.baseurl}${window.GRAPHQL_ENDPOINT}`
+  } else {
+    url = `${window.location.protocol}//${host}${window.GRAPHQL_ENDPOINT}`
+    subscriptionUrl = `${websocketProtocol}//${host}${window.GRAPHQL_ENDPOINT}`
+  }
 
   const availablePlugins = window.GRAPHIQL_PLUGIN_LIST
     .map(plugin => window[`GRAPIHQL_PLUGIN_${plugin.toUpperCase()}`])


### PR DESCRIPTION
fix - https://github.com/mercurius-js/mercurius/issues/1003 issue. 

The graphiql failed to load schema when it's been deployed on https://foo.com/bar/graphiql, it will look for the schema at https://foo.com/graphql but it's actually running on https://foo.com/bar/graphql, which is an invalid graphql endpoint as it is missing window.baseUrl. So we are addressing this in the PR. 


![image](https://github.com/mercurius-js/mercurius/assets/111346255/9b965276-55d3-4e9e-8799-4fe464ccc54a)


Thank you @ddai1  for help here. 
