### PR TITLE
bugfix: window.baseurl is not working in all the cases to fix this using window.location.pathname

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -101,8 +101,14 @@ function render () {
   let url = ''
   let subscriptionUrl = ''
   if (window.baseurl) {
-    url = `${window.location.protocol}//${host}${window.baseurl}${window.GRAPHQL_ENDPOINT}`
-    subscriptionUrl = `${websocketProtocol}//${host}${window.baseurl}${window.GRAPHQL_ENDPOINT}`
+    let pathname = window.location.pathname
+    if (pathname.startsWith('/')) {
+      pathname = pathname.substring(1)
+    }
+    pathname = pathname.split('/')
+    const baseurl = parts[0]
+    url = `${window.location.protocol}//${host}${baseurl}${window.GRAPHQL_ENDPOINT}`
+    subscriptionUrl = `${websocketProtocol}//${host}${baseurl}${window.GRAPHQL_ENDPOINT}`
   } else {
     url = `${window.location.protocol}//${host}${window.GRAPHQL_ENDPOINT}`
     subscriptionUrl = `${websocketProtocol}//${host}${window.GRAPHQL_ENDPOINT}`

--- a/static/main.js
+++ b/static/main.js
@@ -100,15 +100,15 @@ function render () {
   const websocketProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
   let url = ''
   let subscriptionUrl = ''
-  if (window.baseurl) {
-    let pathname = window.location.pathname
-    if (pathname.startsWith('/')) {
-      pathname = pathname.substring(1)
-    }
-    pathname = pathname.split('/')
-    const baseurl = parts[0]
-    url = `${window.location.protocol}//${host}${baseurl}${window.GRAPHQL_ENDPOINT}`
-    subscriptionUrl = `${websocketProtocol}//${host}${baseurl}${window.GRAPHQL_ENDPOINT}`
+  let pathName = window.location.pathname
+  if (pathName.startsWith('/')) {
+    pathName = pathName.substring(1)
+  }
+  pathName = pathName.split('/')
+  const baseUrl = pathName[0]
+  if (baseUrl !== 'graphiql') {
+    url = `${window.location.protocol}//${host}${baseUrl}${window.GRAPHQL_ENDPOINT}`
+    subscriptionUrl = `${websocketProtocol}//${host}${baseUrl}${window.GRAPHQL_ENDPOINT}`
   } else {
     url = `${window.location.protocol}//${host}${window.GRAPHQL_ENDPOINT}`
     subscriptionUrl = `${websocketProtocol}//${host}${window.GRAPHQL_ENDPOINT}`

--- a/static/main.js
+++ b/static/main.js
@@ -107,8 +107,8 @@ function render () {
   pathName = pathName.split('/')
   const baseUrl = pathName[0]
   if (baseUrl !== 'graphiql') {
-    url = `${window.location.protocol}//${host}${baseUrl}${window.GRAPHQL_ENDPOINT}`
-    subscriptionUrl = `${websocketProtocol}//${host}${baseUrl}${window.GRAPHQL_ENDPOINT}`
+    url = `${window.location.protocol}//${host}//${baseUrl}${window.GRAPHQL_ENDPOINT}`
+    subscriptionUrl = `${websocketProtocol}//${host}//${baseUrl}${window.GRAPHQL_ENDPOINT}`
   } else {
     url = `${window.location.protocol}//${host}${window.GRAPHQL_ENDPOINT}`
     subscriptionUrl = `${websocketProtocol}//${host}${window.GRAPHQL_ENDPOINT}`

--- a/test.js
+++ b/test.js
@@ -1,9 +1,0 @@
-pathname='/gds-data/v1/cluster-map.json'
-if (pathname.startsWith('/')) {
-    pathname = pathname.substring(1);
-}
-console.log(pathname)
-var parts = pathname.split('/');
-console.log(parts)
-var baseurl = parts[0];
-console.log(baseurl)

--- a/test.js
+++ b/test.js
@@ -1,0 +1,9 @@
+pathname='/gds-data/v1/cluster-map.json'
+if (pathname.startsWith('/')) {
+    pathname = pathname.substring(1);
+}
+console.log(pathname)
+var parts = pathname.split('/');
+console.log(parts)
+var baseurl = parts[0];
+console.log(baseurl)


### PR DESCRIPTION
bugfix:
- The `window.baseurl` is not working as expected as in some cases window.baseurl is undefined. 
- using `window.location.pathname` is better then using `window.baseurl` as in some cases the value is undefined. 