### PR TITLE
feat: support passing options to graphql validate and parse

### DIFF
--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -34,6 +34,9 @@
 - `loaders`: Object. See [defineLoaders](#appgraphqlextendschemaschema-appgraphqldefineresolversresolvers-and-appgraphqldefineloadersloaders) for more
   details.
 - `schemaTransforms`: Array of schema-transformation functions. Accept a schema as an argument and return a schema.
+- `graphql`: Object. Override options for graphql function that Mercurius utilizes.
+  - `parseOptions`: Object. [GraphQL's parse function options](https://github.com/graphql/graphql-js/blob/main/src/language/parser.ts)
+  - `validateOptions`: Object. [GraphQL's validate function options](https://github.com/graphql/graphql-js/blob/main/src/validation/validate.ts)
 - `graphiql`: boolean | string | Object. Serve
   [GraphiQL](https://www.npmjs.com/package/graphiql) on `/graphiql` if `true` or `'graphiql'`. Leave empty or `false` to disable.
   _only applies if `onlyPersisted` option is not `true`_

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,7 @@ import {
   GraphQLScalarType,
   ValidationRule,
   FormattedExecutionResult,
+  ParseOptions,
 } from "graphql";
 import { SocketStream } from "@fastify/websocket"
 import { IncomingMessage, IncomingHttpHeaders, OutgoingHttpHeaders } from "http";
@@ -356,6 +357,15 @@ export interface MercuriusGraphiQLOptions {
   }>
 }
 
+export interface GrapQLValidateOptions {
+  maxErrors?: number;
+}
+
+export interface MercuriusGraphQLOptions {
+  parseOptions?: ParseOptions,
+  validateOptions?: GrapQLValidateOptions
+}
+
 export interface MercuriusCommonOptions {
   /**
    * Serve GraphiQL on /graphiql if true or 'graphiql' and if routes is true
@@ -413,6 +423,10 @@ export interface MercuriusCommonOptions {
    * The maximum depth allowed for a single query.
    */
   queryDepth?: number;
+  /**
+   * GraphQL function optional option overrides
+   */
+  graphql?: MercuriusGraphQLOptions,
   context?: (
     request: FastifyRequest,
     reply: FastifyReply

--- a/test/graphql-option-override.js
+++ b/test/graphql-option-override.js
@@ -1,0 +1,142 @@
+'use strict'
+
+const { test } = require('tap')
+const Fastify = require('fastify')
+const mercurius = require('..')
+
+const schema = `
+type User {
+  name: String!
+  password: String!
+}
+
+type Query {
+  read: [User]
+}
+`
+
+const resolvers = {
+  Query: {
+    read: async (_, obj) => {
+      return [
+        {
+          name: 'foo',
+          password: 'bar'
+        }
+      ]
+    }
+  }
+}
+
+const query = `{
+  read {
+    name
+    password
+  }
+}`
+
+const query2 = `{
+  read {
+    intentionallyUnknownField1
+    intentionallyUnknownField2
+    intentionallyUnknownField3
+  }
+}`
+
+test('do not override graphql function options', async t => {
+  const app = Fastify()
+  t.teardown(() => app.close())
+
+  await app.register(mercurius, {
+    schema,
+    resolvers
+  })
+
+  await app.ready()
+
+  const res = await app.graphql(query)
+
+  const expectedResult = {
+    data: {
+      read: [{
+        name: 'foo',
+        password: 'bar'
+      }]
+    }
+  }
+
+  t.same(res, expectedResult)
+})
+
+test('override graphql.parse options', async t => {
+  const app = Fastify()
+  t.teardown(() => app.close())
+
+  await app.register(mercurius, {
+    schema,
+    resolvers,
+    graphql: {
+      parseOptions: {
+        maxTokens: 1
+      }
+    }
+  })
+
+  await app.ready()
+
+  const expectedErr = {
+    errors: [{
+      message: 'Syntax Error: Document contains more that 1 tokens. Parsing aborted.'
+    }]
+  }
+
+  await t.rejects(app.graphql(query), expectedErr)
+})
+
+test('do not override graphql.validate options', async t => {
+  const app = Fastify()
+  t.teardown(() => app.close())
+
+  await app.register(mercurius, {
+    schema,
+    resolvers
+  })
+
+  await app.ready()
+
+  const expectedErr = {
+    errors: [
+      { message: 'Cannot query field "intentionallyUnknownField1" on type "User".' },
+      { message: 'Cannot query field "intentionallyUnknownField2" on type "User".' },
+      { message: 'Cannot query field "intentionallyUnknownField3" on type "User".' }
+    ]
+  }
+
+  await t.rejects(app.graphql(query2), expectedErr)
+})
+
+test('override graphql.validate options', async t => {
+  const app = Fastify()
+  t.teardown(() => app.close())
+
+  await app.register(mercurius, {
+    schema,
+    resolvers,
+    graphql: {
+      validateOptions: {
+        maxErrors: 1
+      }
+    }
+  })
+
+  await app.ready()
+
+  const expectedErr = {
+    errors: [
+      { message: 'Cannot query field "intentionallyUnknownField1" on type "User".' },
+      { message: 'Too many validation errors, error limit reached. Validation aborted.' }
+    ]
+  }
+
+  await t.rejects(app.graphql(query2), expectedErr)
+})


### PR DESCRIPTION
Support passing options to GraphQL's `validate` and `parse` functions.

Reasoning to allow configuration of these functions topics is fine tuning to prevent DDOS attacks.

This allows developers to set:
1. `validate`'s options of `maxErrors` to something more/less than the 100 default. This prevents an attacker from specifying 100 invalid fields, requiring CPU time generating validation errors.
2. `parse`'s options of `maxTokens` to a value. It has no default. This prevent an attacker from producing a overly high complexity query that requires a high amount of CPU time.