### PR TITLE
feat: adding validation to verify if baseUrl is already present in th…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mercurius",
-  "version": "13.3.0",
+  "version": "13.3.1",
   "description": "Fastify GraphQL adapter with subscription support",
   "main": "index.js",
   "types": "index.d.ts",

--- a/static/main.js
+++ b/static/main.js
@@ -95,6 +95,17 @@ function fetcherWrapper (fetcher, cbs = []) {
   }
 }
 
+/**
+ * Verify if the baseUrl is already present in the first part of GRAPHQL_ENDPOINT url
+ * to avoid unexpected duplication of paths
+ * @param {string} baseUrl [comes from {@link render} function]
+ * @returns boolean
+ */
+function isDuplicatedUrlArg (baseUrl) {
+  const checker = window.GRAPHQL_ENDPOINT.split('/')
+  return (checker[1] === baseUrl)
+}
+
 function render () {
   const host = window.location.host
   const websocketProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
@@ -109,6 +120,10 @@ function render () {
   if (baseUrl !== 'graphiql') {
     url = `${window.location.protocol}//${host}/${baseUrl}${window.GRAPHQL_ENDPOINT}`
     subscriptionUrl = `${websocketProtocol}//${host}/${baseUrl}${window.GRAPHQL_ENDPOINT}`
+    if (isDuplicatedUrlArg(baseUrl)) {
+      url = `${window.location.protocol}//${host}${window.GRAPHQL_ENDPOINT}`
+      subscriptionUrl = `${websocketProtocol}//${host}${window.GRAPHQL_ENDPOINT}`
+    }
   } else {
     url = `${window.location.protocol}//${host}${window.GRAPHQL_ENDPOINT}`
     subscriptionUrl = `${websocketProtocol}//${host}${window.GRAPHQL_ENDPOINT}`


### PR DESCRIPTION
closes https://github.com/mercurius-js/mercurius/issues/1046

- adding validation to prevent path duplication when prefix is set.
- prevent GraphiQL of getting error 404 to request GraphQL API endpoint.