### PR TITLE
Feat: add the ability to add in additional route properties

### DIFF
--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -89,7 +89,7 @@
 - `allowBatchedQueries`: Boolean. Flag to control whether to allow batched queries. When `true`, the server supports recieving an array of queries and returns an array of results.
 
 - `compilerOptions`: Object. Configurable options for the graphql-jit compiler. For more details check https://github.com/zalando-incubator/graphql-jit
-- `additionalRouteProps`: Object. Takes similar configuration to the Route Options of Fastify. Usecases include being able to add constraints, modify validation schema, increase the `bodyLimit`, etc. You can read more about the possible values on [fastify.dev's Routes Options](https://fastify.dev/docs/latest/Reference/Routes/#options)
+- `additionalRouteOptions`: Object. Takes similar configuration to the Route Options of Fastify. Use cases include being able to add constraints, modify validation schema, increase the `bodyLimit`, etc. You can read more about the possible values on [fastify.dev's Routes Options](https://fastify.dev/docs/latest/Reference/Routes/#options)
 
 #### queryDepth example
 

--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -89,6 +89,7 @@
 - `allowBatchedQueries`: Boolean. Flag to control whether to allow batched queries. When `true`, the server supports recieving an array of queries and returns an array of results.
 
 - `compilerOptions`: Object. Configurable options for the graphql-jit compiler. For more details check https://github.com/zalando-incubator/graphql-jit
+- `additionalRouteProps`: Object. Takes similar configuration to the Route Options of Fastify. Usecases include being able to add constraints, modify validation schema, increase the `bodyLimit`, etc. You can read more about the possible values on [fastify.dev's Routes Options](https://fastify.dev/docs/latest/Reference/Routes/#options)
 
 #### queryDepth example
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@ import {
   FastifyReply,
   FastifyRequest,
   FastifyInstance,
+  RouteOptions
 } from "fastify";
 import {
   DocumentNode,
@@ -487,6 +488,18 @@ declare namespace mercurius {
      * receive an array of responses within a single request.
      */
     allowBatchedQueries?: boolean;
+
+    /**
+     * Customize the graphql routers initialized by mercurius with 
+     * more fastify route options. 
+     * 
+     * Usecases:
+     * - Add more validation 
+     * - change how the schema behaves 
+     * - Hook on the request's life cycle
+     * - Increase body size limit for larger queries
+    */
+    additionalRouteProps?:Omit<RouteOptions,"handler" | "wsHandler">
   }
   
   export type MercuriusOptions = MercuriusCommonOptions & (MercuriusSchemaOptions)

--- a/index.d.ts
+++ b/index.d.ts
@@ -499,7 +499,7 @@ declare namespace mercurius {
      * - Hook on the request's life cycle
      * - Increase body size limit for larger queries
     */
-    additionalRouteOptions?:Omit<RouteOptions,"handler" | "wsHandler">
+    additionalRouteOptions?:Omit<RouteOptions,"handler"|"wsHandler"|"method"|"url">
   }
   
   export type MercuriusOptions = MercuriusCommonOptions & (MercuriusSchemaOptions)

--- a/index.d.ts
+++ b/index.d.ts
@@ -495,7 +495,7 @@ declare namespace mercurius {
      * 
      * Usecases:
      * - Add more validation 
-     * - change how the schema behaves 
+     * - change the schema structure 
      * - Hook on the request's life cycle
      * - Increase body size limit for larger queries
     */

--- a/index.d.ts
+++ b/index.d.ts
@@ -499,7 +499,7 @@ declare namespace mercurius {
      * - Hook on the request's life cycle
      * - Increase body size limit for larger queries
     */
-    additionalRouteProps?:Omit<RouteOptions,"handler" | "wsHandler">
+    additionalRouteOptions?:Omit<RouteOptions,"handler" | "wsHandler">
   }
   
   export type MercuriusOptions = MercuriusCommonOptions & (MercuriusSchemaOptions)

--- a/index.js
+++ b/index.js
@@ -210,7 +210,8 @@ const mercurius = fp(async function (app, opts) {
       entityResolversFactory: undefined,
       subscriptionContextFn,
       keepAlive,
-      fullWsTransport
+      fullWsTransport,
+      additionalRouteProps: opts.additionalRouteProps
     })
   }
 

--- a/index.js
+++ b/index.js
@@ -211,7 +211,7 @@ const mercurius = fp(async function (app, opts) {
       subscriptionContextFn,
       keepAlive,
       fullWsTransport,
-      additionalRouteProps: opts.additionalRouteProps
+      additionalRouteOptions: opts.additionalRouteOptions
     })
   }
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -200,7 +200,8 @@ module.exports = async function (app, opts) {
     persistedQueryProvider,
     allowBatchedQueries,
     keepAlive,
-    fullWsTransport
+    fullWsTransport,
+    additionalRouteProps
   } = opts
 
   // Load the persisted query settings
@@ -293,6 +294,7 @@ module.exports = async function (app, opts) {
     method: 'GET',
     schema: getSchema,
     attachValidation: true,
+    ...additionalRouteProps,
     handler: async function (request, reply) {
       // Generate the context for this request
       if (contextFn) {
@@ -338,7 +340,8 @@ module.exports = async function (app, opts) {
 
   app.post(graphqlPath, {
     schema: postSchema(allowBatchedQueries),
-    attachValidation: true
+    attachValidation: true,
+    ...additionalRouteProps
   }, async function (request, reply) {
     // Generate the context for this request
     if (contextFn) {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -201,7 +201,7 @@ module.exports = async function (app, opts) {
     allowBatchedQueries,
     keepAlive,
     fullWsTransport,
-    additionalRouteProps
+    additionalRouteOptions
   } = opts
 
   // Load the persisted query settings
@@ -215,10 +215,10 @@ module.exports = async function (app, opts) {
     notSupportedError
   } = persistedQueryProvider || {}
 
-  const normalizedRouteProps = { ...additionalRouteProps }
-  if (normalizedRouteProps.handler || normalizedRouteProps.wsHandler) {
-    normalizedRouteProps.handler = undefined
-    normalizedRouteProps.wsHandler = undefined
+  const normalizedRouteOptions = { ...additionalRouteOptions }
+  if (normalizedRouteOptions.handler || normalizedRouteOptions.wsHandler) {
+    normalizedRouteOptions.handler = undefined
+    normalizedRouteOptions.wsHandler = undefined
   }
 
   async function executeQuery (query, variables, operationName, request, reply) {
@@ -300,7 +300,7 @@ module.exports = async function (app, opts) {
     method: 'GET',
     schema: getSchema,
     attachValidation: true,
-    ...normalizedRouteProps,
+    ...normalizedRouteOptions,
     handler: async function (request, reply) {
       // Generate the context for this request
       if (contextFn) {
@@ -347,7 +347,7 @@ module.exports = async function (app, opts) {
   app.post(graphqlPath, {
     schema: postSchema(allowBatchedQueries),
     attachValidation: true,
-    ...normalizedRouteProps
+    ...normalizedRouteOptions
   }, async function (request, reply) {
     // Generate the context for this request
     if (contextFn) {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -215,6 +215,12 @@ module.exports = async function (app, opts) {
     notSupportedError
   } = persistedQueryProvider || {}
 
+  const normalizedRouteProps = { ...additionalRouteProps }
+  if (normalizedRouteProps.handler || normalizedRouteProps.wsHandler) {
+    normalizedRouteProps.handler = undefined
+    normalizedRouteProps.wsHandler = undefined
+  }
+
   async function executeQuery (query, variables, operationName, request, reply) {
     // Validate a query is present
     if (!query) {
@@ -294,7 +300,7 @@ module.exports = async function (app, opts) {
     method: 'GET',
     schema: getSchema,
     attachValidation: true,
-    ...additionalRouteProps,
+    ...normalizedRouteProps,
     handler: async function (request, reply) {
       // Generate the context for this request
       if (contextFn) {
@@ -341,7 +347,7 @@ module.exports = async function (app, opts) {
   app.post(graphqlPath, {
     schema: postSchema(allowBatchedQueries),
     attachValidation: true,
-    ...additionalRouteProps
+    ...normalizedRouteProps
   }, async function (request, reply) {
     // Generate the context for this request
     if (contextFn) {

--- a/test/routes.js
+++ b/test/routes.js
@@ -2261,7 +2261,7 @@ test('GET graphql endpoint, additionalRouteProps should ignore custom handler', 
   app.register(GQL, {
     schema,
     additionalRouteProps: {
-      // @ts-ignore
+      // @ts-expect-error `handler` property is ignored in props
       handler (req, reply) {
         executed = true
       }

--- a/test/routes.js
+++ b/test/routes.js
@@ -2197,7 +2197,7 @@ test('GET graphql endpoint with invalid additionalRouteProp constraint', async (
   `
   app.register(GQL, {
     schema,
-    additionalRouteProps: {
+    additionalRouteOptions: {
       constraints: {
         host: 'auth.fastify.dev'
       }
@@ -2224,7 +2224,7 @@ test('GET graphql endpoint with valid additionalRouteProp constraint', async (t)
   `
   app.register(GQL, {
     schema,
-    additionalRouteProps: {
+    additionalRouteOptions: {
       constraints: {
         host: 'auth.fastify.dev'
       }
@@ -2248,7 +2248,7 @@ test('GET graphql endpoint with valid additionalRouteProp constraint', async (t)
   t.equal(res.statusCode, 200)
 })
 
-test('GET graphql endpoint, additionalRouteProps should ignore custom handler', async (t) => {
+test('GET graphql endpoint, additionalRouteOptions should ignore custom handler', async (t) => {
   const app = Fastify()
   const schema = `
     type Query {
@@ -2260,7 +2260,7 @@ test('GET graphql endpoint, additionalRouteProps should ignore custom handler', 
 
   app.register(GQL, {
     schema,
-    additionalRouteProps: {
+    additionalRouteOptions: {
       // @ts-expect-error `handler` property is ignored in props
       handler (req, reply) {
         executed = true

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -265,6 +265,13 @@ makeGraphqlServer({
 })
 makeGraphqlServer({ schema, errorFormatter: mercurius.defaultErrorFormatter })
 makeGraphqlServer({ schema: [schema, 'extend type Query { foo: String }'] })
+makeGraphqlServer({
+  additionalRouteOptions: {
+    constraints: {
+      version: '1.2'
+    }
+  }
+})
 
 // Subscriptions
 


### PR DESCRIPTION
# Changes 
ability to add and modify route properties to modify how the routes might behave. One example is to be able to create a schema split which https://github.com/nearform/mercurius-dynamic-schema/ tries to achieve. 

## Reasoning
Helps close https://github.com/nearform/mercurius-dynamic-schema/issues/4