### PR TITLE
fix: undici security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "concurrently": "^8.0.1",
     "docsify-cli": "^4.4.3",
     "fastify": "^4.17.0",
-    "graphql-ws": "^5.11.2",
     "graphql": "^16.0.0",
+    "graphql-ws": "^5.11.2",
     "pre-commit": "^1.2.2",
     "proxyquire": "^2.1.3",
     "semver": "^7.5.0",
@@ -70,7 +70,7 @@
     "secure-json-parse": "^2.7.0",
     "single-user-cache": "^0.6.0",
     "tiny-lru": "^11.0.0",
-    "undici": "5.28.1",
+    "undici": "5.28.3",
     "ws": "^8.2.2"
   },
   "tsd": {


### PR DESCRIPTION
```
# npm audit report

undici  <=5.28.2
Undici proxy-authorization header not cleared on cross-origin redirect in fetch - https://github.com/advisories/GHSA-3787-6prv-h9w3
```