### PR TITLE
feat: make request available in context by default

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -30,6 +30,7 @@ declare namespace mercurius {
   
   export interface MercuriusContext {
     app: FastifyInstance;
+    request: FastifyRequest;
     reply: FastifyReply;
     operationsCount?: number;
     operationId?: number;

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -305,9 +305,9 @@ module.exports = async function (app, opts) {
       // Generate the context for this request
       if (contextFn) {
         request[kRequestContext] = await contextFn(request, reply)
-        Object.assign(request[kRequestContext], { reply, app })
+        Object.assign(request[kRequestContext], { request, reply, app })
       } else {
-        request[kRequestContext] = { reply, app }
+        request[kRequestContext] = { request, reply, app }
       }
 
       validationHandler(request.validationError)

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -63,7 +63,7 @@ const resolvers: IResolvers = {
 // declare module 'mercurius' {
 declare module '../../' {
   interface MercuriusContext { // eslint-disable-line
-    request: FastifyRequest
+    extra: boolean
   }
 }
 
@@ -89,9 +89,9 @@ app.register(mercurius, {
   },
   queryDepth: 8,
   cache: true,
-  context: (request) => {
+  context: () => {
     return {
-      request
+      extra: true
     }
   },
   schemaTransforms: (schema) => schema
@@ -117,9 +117,9 @@ app.register(mercurius, {
   },
   queryDepth: 8,
   cache: true,
-  context: (request) => {
+  context: () => {
     return {
-      request
+      extra: true
     }
   },
   schemaTransforms: (schema) => schema
@@ -197,6 +197,7 @@ app.register(async function (app) {
   app.graphql.defineResolvers({
     Query: {
       dogs (_root, _params, ctx) {
+        ctx.extra
         ctx.request
         ctx.reply
         ctx.pubsub


### PR DESCRIPTION
I know this is very easy to define a custom context for, but it's annoying to have to do it every time and this is a closer match to standard Fastify handlers.