### PR TITLE
fix: handle if error.originalError.errors is not array

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -44,7 +44,7 @@ function defaultErrorFormatter (execution, ctx) {
     log.info({ err: error }, error.message)
 
     // it handles fastify errors MER_ERR_GQL_VALIDATION
-    if (error.originalError?.errors) {
+    if (error.originalError?.errors && Array.isArray(error.originalError.errors)) {
       // not all errors are `GraphQLError` type, we need to convert them
       return error.originalError.errors.map(toGraphQLError)
     }


### PR DESCRIPTION
fixes #1024

* Current unit test handle coverage so no test was added
* Fix: Check that `error.orginialError.errors` is an `Array`