### PR TITLE
fix: updates undici to keep up with latest security release

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "secure-json-parse": "^2.7.0",
     "single-user-cache": "^0.6.0",
     "tiny-lru": "^11.0.0",
-    "undici": "5.28.4",
+    "undici": "^5.28.4",
     "ws": "^8.2.2"
   },
   "tsd": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "secure-json-parse": "^2.7.0",
     "single-user-cache": "^0.6.0",
     "tiny-lru": "^11.0.0",
-    "undici": "5.28.3",
+    "undici": "5.28.4",
     "ws": "^8.2.2"
   },
   "tsd": {


### PR DESCRIPTION
Updates undici to keep up with latest security related release of the 5.x.x. version branch, see [undici release info](https://github.com/nodejs/undici/releases/tag/v5.28.4) for more information.

npm audit output:

```
undici  <=5.28.3
Undici's Proxy-Authorization header not cleared on cross-origin redirect for dispatch, request, stream, pipeline - https://github.com/advisories/GHSA-m4v8-wqvr-p9f7
Undici's fetch with integrity option is too lax when algorithm is specified but hash value is in incorrect - https://github.com/advisories/GHSA-9qxr-qj54-h672
```