### PR TITLE
Error through subscription wrapped in an array

### DIFF
--- a/lib/subscription-connection.js
+++ b/lib/subscription-connection.js
@@ -8,6 +8,7 @@ const { MER_ERR_GQL_SUBSCRIPTION_FORBIDDEN, MER_ERR_GQL_SUBSCRIPTION_UNKNOWN_EXT
 const { preSubscriptionParsingHandler, onSubscriptionResolutionHandler, preSubscriptionExecutionHandler, onSubscriptionEndHandler } = require('./handlers')
 const { kSubscriptionFactory, kLoaders } = require('./symbols')
 const { getProtocolByName } = require('./subscription-protocol')
+const { toGraphQLError } = require('./errors')
 
 module.exports = class SubscriptionConnection {
   constructor (socket, {
@@ -63,7 +64,7 @@ module.exports = class SubscriptionConnection {
     try {
       data = sJSON.parse(isBinary ? message : message.toString())
     } catch (e) {
-      this.sendMessage(this.protocolMessageTypes.GQL_ERROR, null, 'Message must be a JSON string')
+      this.sendError(new Error('Message must be a JSON string'), null)
       return
     }
 
@@ -78,11 +79,7 @@ module.exports = class SubscriptionConnection {
       case this.protocolMessageTypes.GQL_START: {
         if (this.isReady) {
           this.handleGQLStart(data).catch((e) => {
-            this.sendMessage(
-              this.protocolMessageTypes.GQL_ERROR,
-              id,
-              e.message
-            )
+            this.sendError(e, id)
           })
         } else {
           this.sendMessage(
@@ -116,11 +113,7 @@ module.exports = class SubscriptionConnection {
           break
         }
 
-        this.sendMessage(
-          this.protocolMessageTypes.GQL_ERROR,
-          id,
-          'Invalid payload type'
-        )
+        this.sendError(new Error('Invalid payload type'), id)
     }
   }
 
@@ -387,6 +380,12 @@ module.exports = class SubscriptionConnection {
     } catch (e) {
       this.handleConnectionClose()
     }
+  }
+
+  sendError (err, id) {
+    const convertedError = toGraphQLError(err)
+    // Graphql over websocket spec requires that errors are wrapped in an array
+    this.sendMessage(this.protocolMessageTypes.GQL_ERROR, id, [convertedError])
   }
 
   async handleConnectionInitExtension (extension) {

--- a/test/subscription-connection.js
+++ b/test/subscription-connection.js
@@ -73,7 +73,7 @@ test('subscription connection sends error message when message is not json strin
       t.equal(JSON.stringify({
         type: 'error',
         id: null,
-        payload: 'Message must be a JSON string'
+        payload: [{ message: 'Message must be a JSON string' }]
       }), message)
     },
     protocol: GRAPHQL_TRANSPORT_WS
@@ -255,7 +255,7 @@ test('subscription connection send error message when GQL_START handler errs', a
       t.equal(JSON.stringify({
         type: 'error',
         id: 1,
-        payload: 'handleGQLStart error'
+        payload: [{ message: 'handleGQLStart error' }]
       }), message)
     },
     protocol: GRAPHQL_TRANSPORT_WS
@@ -284,7 +284,7 @@ test('subscription connection send error message when client message type is inv
       t.equal(JSON.stringify({
         type: 'error',
         id: 1,
-        payload: 'Invalid payload type'
+        payload: [{ message: 'Invalid payload type' }]
       }), message)
     },
     protocol: GRAPHQL_TRANSPORT_WS
@@ -305,7 +305,7 @@ test('subscription connection handles GQL_START message correctly, when payload.
     close () {},
     send (message) {
       t.equal(JSON.stringify(
-        { type: 'error', id: 1, payload: 'Must provide document.' }
+        { type: 'error', id: 1, payload: [{ message: 'Must provide document.' }] }
       ), message)
     },
     protocol: GRAPHQL_TRANSPORT_WS
@@ -440,7 +440,7 @@ test('subscription connection send GQL_ERROR message if connectionInit extension
       t.same(JSON.parse(message), {
         id: 1,
         type: 'error',
-        payload: 'Forbidden'
+        payload: [{ message: 'Forbidden' }]
       })
     },
     protocol: GRAPHQL_TRANSPORT_WS
@@ -509,7 +509,7 @@ test('subscription connection send GQL_ERROR on unknown extension', async (t) =>
       t.same(JSON.parse(message), {
         id: 1,
         type: 'error',
-        payload: 'Unknown extension unknown'
+        payload: [{ message: 'Unknown extension unknown' }]
       })
     },
     protocol: GRAPHQL_TRANSPORT_WS
@@ -584,7 +584,7 @@ test('subscription connection sends error when trying to execute invalid operati
           JSON.stringify({
             type: 'error',
             id: 1,
-            payload: 'Invalid operation: query'
+            payload: [{ message: 'Invalid operation: query' }]
           }),
           message
         )

--- a/test/subscription-hooks.js
+++ b/test/subscription-hooks.js
@@ -218,7 +218,7 @@ test('subscription - should handle preSubscriptionParsing hook errors', async t 
     t.same(data, {
       id: 1,
       type: 'error',
-      payload: 'a preSubscriptionParsing error occurred'
+      payload: [{ message: 'a preSubscriptionParsing error occurred' }]
     })
   }
 })
@@ -268,7 +268,7 @@ test('subscription - should handle preSubscriptionExecution hook errors', async 
     t.same(data, {
       id: 1,
       type: 'error',
-      payload: 'a preSubscriptionExecution error occurred'
+      payload: [{ message: 'a preSubscriptionExecution error occurred' }]
     })
   }
 })

--- a/test/subscription.js
+++ b/test/subscription.js
@@ -1049,7 +1049,11 @@ test('subscription server sends correct error if execution throws', t => {
         t.equal(chunk, JSON.stringify({
           type: 'error',
           id: 1,
-          payload: 'custom execution error'
+          payload: [{
+            message: 'custom execution error',
+            locations: [{ line: 3, column: 13 }],
+            path: ['notificationAdded']
+          }]
         }))
 
         client.end()


### PR DESCRIPTION
The graphql-ws protocol specifies that the payload of an `'error'` message should be an array of GraphQL errors. ([ref](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md#error))

To accommodate this, I created the sendError function to manage the transformation and updated all related tests accordingly.