### PR TITLE
made mercurius's implicitly injected pubsub subscribe/publish methods type safe

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,9 +23,21 @@ import { Readable } from 'stream'
 type Mercurius = typeof mercurius
 
 declare namespace mercurius {
-  export interface PubSub {
-    subscribe<TResult = any>(topics: string | string[]): Promise<Readable & AsyncIterableIterator<TResult>>;
-    publish<TResult = any>(event: { topic: string; payload: TResult }, callback?: () => void): void;
+  export interface PubSubTopics {
+    [topic: string]: any;
+  }
+
+  export interface PubSub<TPubSubTopics extends PubSubTopics = PubSubTopics> {
+    subscribe<TTopic extends Extract<keyof TPubSubTopics, string>>(
+      topics: TTopic | TTopic[],
+    ): Promise<Readable & AsyncIterableIterator<TPubSubTopics[TTopic]>>;
+    publish<TTopic extends Extract<keyof TPubSubTopics, string>>(
+      event: {
+        topic: TTopic;
+        payload: TPubSubTopics[TTopic];
+      },
+      callback?: () => void,
+    ): void;
   }
 
   export interface MercuriusContext {

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -398,7 +398,7 @@ app.graphql.pubsub.publish({
 })
 
 async () => {
-  const subscription = await app.graphql.pubsub.subscribe<{ newNotification: string }>('topic')
+  const subscription = await app.graphql.pubsub.subscribe('topic')
 
   subscription.on('data', (chunk) => {
     console.log(chunk)


### PR DESCRIPTION
The rationale is that mercurius implicitly injects the `pubsub` field into the context received by the graphql resolvers. For making the context type-safe we need to define a custom context type to annotate its typescript type correctly for usage in the graphql resolvers and its in that context type where we can annotate the typescript type for `pubsub` object correctly for usage in the graphql resolvers by having the option of providing strict `event_name-payload` types to the `pubsub.subscribe` and `pubsub.publish` methods.

Usage is shown in the `example.ts` file present in the root directory of [this](https://stackblitz.com/~/github.com/mercurius-js/mercurius) stackblitz example with proper comments.

This implementation is inspired by [this](https://github.com/dotansimha/graphql-yoga/blob/fbe0bebad53597ab36407e3228ecbb9ca4a330c8/packages/subscription/src/create-pub-sub.ts#L36) implementation of pubsub by graphql-yoga but its made to work with mercurius's implementation of pubsub. 

Ideally mercurius should provide an explicit way of either correctly passing the types for these `event_name-payload` that are to be used in `pubsub.subscribe` and `pubsub.publish` functions or it should provide an explicit way of initializing the pubsub object instead of implicitly injecting it into the graphql context.