### PR TITLE
updated graphiql and react to the latest stable versions

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -157,7 +157,7 @@ function render () {
 
 function importDependencies () {
   const link = document.createElement('link')
-  link.href = 'https://unpkg.com/graphiql@2.0.9/graphiql.min.css'
+  link.href = 'https://unpkg.com/graphiql@3.7.1/graphiql.min.css'
   link.type = 'text/css'
   link.rel = 'stylesheet'
   link.media = 'screen,print'
@@ -165,9 +165,9 @@ function importDependencies () {
   document.getElementsByTagName('head')[0].appendChild(link)
 
   return importer.urls([
-    'https://unpkg.com/react@18.2.0/umd/react.production.min.js',
-    'https://unpkg.com/react-dom@18.2.0/umd/react-dom.production.min.js',
-    'https://unpkg.com/graphiql@2.0.9/graphiql.min.js'
+    'https://unpkg.com/react@18.3.1/umd/react.production.min.js',
+    'https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js',
+    'https://unpkg.com/graphiql@3.7.1/graphiql.min.js'
   ]).then(function () {
     const pluginUrls = window.GRAPHIQL_PLUGIN_LIST
       .map(plugin => window[`GRAPIHQL_PLUGIN_${plugin.toUpperCase()}`].umdUrl)

--- a/static/sw.js
+++ b/static/sw.js
@@ -2,13 +2,13 @@
 
 self.addEventListener('install', function (e) {
   e.waitUntil(
-    caches.open('graphiql-v2.0.9').then(function (cache) {
+    caches.open('graphiql-v3.7.1').then(function (cache) {
       return cache.addAll([
         './main.js',
-        'https://unpkg.com/graphiql@2.0.9/graphiql.css',
-        'https://unpkg.com/react@18.2.0/umd/react.production.min.js',
-        'https://unpkg.com/react-dom@18.2.0/umd/react-dom.production.min.js',
-        'https://unpkg.com/graphiql@2.0.9/graphiql.min.js'
+        'https://unpkg.com/graphiql@3.7.1/graphiql.css',
+        'https://unpkg.com/react@18.3.1/umd/react.production.min.js',
+        'https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js',
+        'https://unpkg.com/graphiql@3.7.1/graphiql.min.js'
       ])
     })
   )


### PR DESCRIPTION
Updated the graphiql and react versions to how they're used in the official graphiql example([link](https://github.com/graphql/graphiql/blob/main/examples/graphiql-cdn/index.html) for reference) for the same.

Because of hard locking graphiql was locked to version 2.0.9 when the latest stable graphiql version is 3.7.1. The graphiql version 3.7.1 seems to work without issues with mercurius. React follows semantic versioning so no point in hard locking it to a patch version. 

Update: Restored hard locking, versions are hard locked to the latest stable versions