### PR TITLE
feat: improve PersistedQueryProvider types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -629,7 +629,7 @@ declare namespace mercurius {
     /**
      *  Return the query for a given hash.
      */
-    getQueryFromHash: (hash: string) => Promise<string>;
+    getQueryFromHash: (hash: string) => Promise<string | undefined>;
     /**
      *  Return the hash for a given query string. Do not provide if you want to skip saving new queries.
      */

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -654,3 +654,36 @@ expectType<typeof mercurius.ErrorWithProps>(ErrorWithProps)
 expectType<typeof mercurius.defaultErrorFormatter>(defaultErrorFormatter)
 expectType<typeof mercurius.persistedQueryDefaults>(persistedQueryDefaults)
 expectType<typeof mercurius.withFilter>(withFilter)
+
+app.register(mercurius, {
+  schema,
+  resolvers,
+  persistedQueryProvider: {
+    ...persistedQueryDefaults.automatic(),
+    getQueryFromHash: () => {
+      return Promise.resolve('foo')
+    },
+  }
+})
+
+app.register(mercurius, {
+  schema,
+  resolvers,
+  persistedQueryProvider: {
+    ...persistedQueryDefaults.automatic(),
+    getQueryFromHash: () => {
+      return Promise.resolve(undefined)
+    },
+  }
+})
+
+expectError(app.register(mercurius, {
+  schema,
+  resolvers,
+  persistedQueryProvider: {
+    ...persistedQueryDefaults.automatic(),
+    getQueryFromHash: () => {
+      return Promise.resolve(false)
+    },
+  }
+}))


### PR DESCRIPTION
While implementing a custom PersistedQueryProvider, we noticed that the types were not correct for the "getQueryFromHash" function. In fact, the function may return undefined if the query does not exist, but as of now the types do not allow that.

This PR fixes this (small) issue.