### PR TITLE
chore: update fastify to ^5.0.0, because it is currently in alpha version

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "concurrently": "^9.0.0",
     "docsify-cli": "^4.4.3",
     "eslint": "^9.9.1",
-    "fastify": "^5.0.0-alpha.4",
+    "fastify": "^5.0.0",
     "graphql": "^16.0.0",
     "graphql-tag": "^2.12.6",
     "graphql-ws": "^5.11.2",


### PR DESCRIPTION
Proposal:

- Update `fastify` version `5.0.0` in the `package.json`, currently the version of `5.0.0-alpha.4` is used