### PR TITLE
fix: linting regressions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -199,7 +199,7 @@ declare namespace mercurius {
     ): Promise<void> | void;
   }
 
-  interface ServiceConfig {
+  export interface ServiceConfig {
     setSchema: (schema: string) => ServiceConfig;
   }
 
@@ -314,7 +314,7 @@ declare namespace mercurius {
     extensions?: object;
   }
 
-  interface WsConnectionParams {
+  export interface WsConnectionParams {
     connectionInitPayload?:
       | (() => Record<string, any> | Promise<Record<string, any>>)
       | Record<string, any>;


### PR DESCRIPTION
In the canary tests for the `neostandard` lockfile maintenance it was discovered that with the latest dependencies two errors that had previously not been found in Mercurius was now found: https://github.com/neostandard/neostandard/pull/258

This fixes those two errors by exporting the two interfaces that's unused.