### PR TITLE
simple(graphiql): bump GraphiQL version to 3.8.3

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -157,7 +157,7 @@ function render () {
 
 function importDependencies () {
   const link = document.createElement('link')
-  link.href = 'https://unpkg.com/graphiql@3.7.1/graphiql.min.css'
+  link.href = 'https://unpkg.com/graphiql@3.8.3/graphiql.min.css'
   link.type = 'text/css'
   link.rel = 'stylesheet'
   link.media = 'screen,print'
@@ -167,7 +167,7 @@ function importDependencies () {
   return importer.urls([
     'https://unpkg.com/react@18.3.1/umd/react.production.min.js',
     'https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js',
-    'https://unpkg.com/graphiql@3.7.1/graphiql.min.js'
+    'https://unpkg.com/graphiql@3.8.3/graphiql.min.js'
   ]).then(function () {
     const pluginUrls = window.GRAPHIQL_PLUGIN_LIST
       .map(plugin => window[`GRAPIHQL_PLUGIN_${plugin.toUpperCase()}`].umdUrl)

--- a/static/sw.js
+++ b/static/sw.js
@@ -2,13 +2,13 @@
 
 self.addEventListener('install', function (e) {
   e.waitUntil(
-    caches.open('graphiql-v3.7.1').then(function (cache) {
+    caches.open('graphiql-v3.8.3').then(function (cache) {
       return cache.addAll([
         './main.js',
-        'https://unpkg.com/graphiql@3.7.1/graphiql.css',
+        'https://unpkg.com/graphiql@3.8.3/graphiql.css',
         'https://unpkg.com/react@18.3.1/umd/react.production.min.js',
         'https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js',
-        'https://unpkg.com/graphiql@3.7.1/graphiql.min.js'
+        'https://unpkg.com/graphiql@3.8.3/graphiql.min.js'
       ])
     })
   )


### PR DESCRIPTION
Updated URLs in the service worker to use GraphiQL v3.8.3.
Ensures latest UI fixes & compatibility improvements.