### PR TITLE
feat: custom pubsub with custom args on subscribe method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,7 @@ import {
 import type { WebSocket } from 'ws'
 import { IncomingMessage, OutgoingHttpHeaders } from 'http'
 import { Readable } from 'stream'
+import { EventEmitter } from 'events'
 
 type Mercurius = typeof mercurius
 
@@ -37,6 +38,19 @@ declare namespace mercurius {
         payload: TPubSubTopics[TTopic];
       },
       callback?: () => void,
+    ): void;
+  }
+
+  export interface CustomPubSub {
+    emitter: EventEmitter;
+    subscribe(
+      topic: string | string[],
+      queue: Readable & { close: () => void },
+      ...customArgs: any[]
+    ): Promise<void>;
+    publish(
+      event: { topic: string, payload: any },
+      callback: () => void
     ): void;
   }
 

--- a/lib/subscriber.js
+++ b/lib/subscriber.js
@@ -46,11 +46,14 @@ class SubscriptionContext {
     })
   }
 
-  subscribe (topics) {
+  // `topics` param can be:
+  // - string: subscribe to a single topic
+  // - array: subscribe to multiple topics
+  subscribe (topics, ...customArgs) {
     if (typeof topics === 'string') {
-      return this.pubsub.subscribe(topics, this.queue).then(() => this.queue)
+      return this.pubsub.subscribe(topics, this.queue, ...customArgs).then(() => this.queue)
     }
-    return Promise.all(topics.map((topic) => this.pubsub.subscribe(topic, this.queue))).then(() => this.queue)
+    return Promise.all(topics.map((topic) => this.pubsub.subscribe(topic, this.queue, ...customArgs))).then(() => this.queue)
   }
 
   publish (event) {


### PR DESCRIPTION
This PR wants to add the capability to have custom params on `subscribe` method using a `CustomPubSub` implementation. This is useful in case you need to get an argument from the subscription method