### PR TITLE
test: migrated persisted.test.js from tap to node:test

### DIFF
--- a/test/persisted.test.js
+++ b/test/persisted.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const Fastify = require('fastify')
 const GQL = require('..')
 
@@ -21,7 +21,7 @@ test('persistedQueryProvider errors when getHash is not provided', async (t) => 
     getHash: null
   }
 
-  t.rejects(async () => {
+  t.assert.rejects(async () => {
     app.register(GQL, {
       schema,
       resolvers,
@@ -50,7 +50,7 @@ test('persistedQueryProvider errors when getQueryFromHash is not provided', asyn
     getQueryFromHash: null
   }
 
-  t.rejects(async () => {
+  t.assert.rejects(async () => {
     app.register(GQL, {
       schema,
       resolvers,
@@ -79,7 +79,7 @@ test('persistedQueryProvider errors when saveQuery is not provided', async (t) =
     saveQuery: null
   }
 
-  t.rejects(async () => {
+  t.assert.rejects(async () => {
     app.register(GQL, {
       schema,
       resolvers,
@@ -122,7 +122,7 @@ test('automatic POST new query', async (t) => {
     }
   })
 
-  t.same(JSON.parse(res.body), { data: { add: 3 } })
+  t.assert.deepEqual(JSON.parse(res.body), { data: { add: 3 } })
 })
 
 test('automatic POST new query, null result hashing a query is handled', async (t) => {
@@ -160,7 +160,7 @@ test('automatic POST new query, null result hashing a query is handled', async (
     }
   })
 
-  t.same(JSON.parse(res.body), { data: { add: 3 } })
+  t.assert.deepEqual(JSON.parse(res.body), { data: { add: 3 } })
 })
 
 test('automatic POST new query, error on saveQuery is handled', async (t) => {
@@ -204,7 +204,7 @@ test('automatic POST new query, error on saveQuery is handled', async (t) => {
     }
   })
 
-  t.same(JSON.parse(res.body), { data: { add: 3 } })
+  t.assert.deepEqual(JSON.parse(res.body), { data: { add: 3 } })
 })
 
 test('automatic POST new persisted query and error', async (t) => {
@@ -241,7 +241,7 @@ test('automatic POST new persisted query and error', async (t) => {
     }
   })
 
-  t.same(JSON.parse(res.body), { data: null, errors: [{ message: 'PersistedQueryNotFound' }] })
+  t.assert.deepEqual(JSON.parse(res.body), { data: null, errors: [{ message: 'PersistedQueryNotFound' }] })
 })
 
 test('automatic POST invalid version persisted query and error', async (t) => {
@@ -278,7 +278,7 @@ test('automatic POST invalid version persisted query and error', async (t) => {
     }
   })
 
-  t.same(JSON.parse(res.body), { data: null, errors: [{ message: 'PersistedQueryNotSupported' }] })
+  t.assert.deepEqual(JSON.parse(res.body), { data: null, errors: [{ message: 'PersistedQueryNotSupported' }] })
 })
 
 test('automatic POST invalid extension and error', async (t) => {
@@ -309,7 +309,7 @@ test('automatic POST invalid extension and error', async (t) => {
     }
   })
 
-  t.same(JSON.parse(res.body), { data: null, errors: [{ message: 'Unknown query' }] })
+  t.assert.deepEqual(JSON.parse(res.body), { data: null, errors: [{ message: 'Unknown query' }] })
 })
 
 test('automatic POST invalid extension without persistedQueries and error', async (t) => {
@@ -343,7 +343,7 @@ test('automatic POST invalid extension without persistedQueries and error', asyn
     }
   })
 
-  t.same(JSON.parse(res.body), { data: null, errors: [{ message: 'PersistedQueryNotSupported' }] })
+  t.assert.deepEqual(JSON.parse(res.body), { data: null, errors: [{ message: 'PersistedQueryNotSupported' }] })
 })
 
 test('avoid persisting POST query', async (t) => {
@@ -378,7 +378,7 @@ test('avoid persisting POST query', async (t) => {
     }
   })
 
-  t.same(JSON.parse(res.body), { data: { add: 3 } })
+  t.assert.deepEqual(JSON.parse(res.body), { data: { add: 3 } })
 
   res = await app.inject({
     method: 'POST',
@@ -395,7 +395,7 @@ test('avoid persisting POST query', async (t) => {
     }
   })
 
-  t.same(JSON.parse(res.body), { data: null, errors: [{ message: 'PersistedQueryNotFound' }] })
+  t.assert.deepEqual(JSON.parse(res.body), { data: null, errors: [{ message: 'PersistedQueryNotFound' }] })
 })
 
 test('automatic POST persisted query after priming, with extension set in both payloads', async (t) => {
@@ -436,7 +436,7 @@ test('automatic POST persisted query after priming, with extension set in both p
     }
   })
 
-  t.same(JSON.parse(res.body), { data: { add: 3 } })
+  t.assert.deepEqual(JSON.parse(res.body), { data: { add: 3 } })
 
   res = await app.inject({
     method: 'POST',
@@ -453,7 +453,7 @@ test('automatic POST persisted query after priming, with extension set in both p
     }
   })
 
-  t.same(JSON.parse(res.body), { data: { add: 3 } })
+  t.assert.deepEqual(JSON.parse(res.body), { data: { add: 3 } })
 })
 
 test('avoid persisting query if hashes mismatch', async (t) => {
@@ -494,7 +494,7 @@ test('avoid persisting query if hashes mismatch', async (t) => {
     }
   })
 
-  t.same(JSON.parse(res.body), { data: null, errors: [{ message: 'provided sha does not match query' }] })
+  t.assert.deepEqual(JSON.parse(res.body), { data: null, errors: [{ message: 'provided sha does not match query' }] })
 })
 
 // persistedQueryProvider
@@ -526,7 +526,7 @@ test('GET route with query, variables & persisted', async (t) => {
     url: '/graphql?query=248eb276edb4f22aced0a2848c539810b55f79d89abc531b91145e76838f5602&persisted=true'
   })
 
-  t.same(JSON.parse(res1.body), {
+  t.assert.deepEqual(JSON.parse(res1.body), {
     data: {
       add: 2
     }
@@ -537,7 +537,7 @@ test('GET route with query, variables & persisted', async (t) => {
     url: '/graphql?query=495ccd73abc8436544cfeedd65f24beee660d2c7be2c32536e3fbf911f935ddf&variables={"x":2,"y":2}&persisted=true'
   })
 
-  t.same(JSON.parse(res2.body), {
+  t.assert.deepEqual(JSON.parse(res2.body), {
     data: {
       add: 4
     }
@@ -548,7 +548,7 @@ test('GET route with query, variables & persisted', async (t) => {
     url: '/graphql?query=03ec1635d1a0ea530672bf33f28f3533239a5a7021567840c541c31d5e28c65e&persisted=true'
   })
 
-  t.same(JSON.parse(res3.body), {
+  t.assert.deepEqual(JSON.parse(res3.body), {
     data: {
       add: 6
     }
@@ -586,7 +586,7 @@ test('POST route with query, variables & persisted', async (t) => {
     }
   })
 
-  t.same(JSON.parse(res1.body), {
+  t.assert.deepEqual(JSON.parse(res1.body), {
     data: {
       add: 2
     }
@@ -602,7 +602,7 @@ test('POST route with query, variables & persisted', async (t) => {
     }
   })
 
-  t.same(JSON.parse(res2.body), {
+  t.assert.deepEqual(JSON.parse(res2.body), {
     data: {
       add: 4
     }
@@ -617,7 +617,7 @@ test('POST route with query, variables & persisted', async (t) => {
     }
   })
 
-  t.same(JSON.parse(res3.body), {
+  t.assert.deepEqual(JSON.parse(res3.body), {
     data: {
       add: 6
     }
@@ -655,7 +655,7 @@ test('preparedOnly POST route with query, variables & persisted', async (t) => {
     }
   })
 
-  t.same(JSON.parse(res1.body), {
+  t.assert.deepEqual(JSON.parse(res1.body), {
     data: {
       add: 2
     }
@@ -671,7 +671,7 @@ test('preparedOnly POST route with query, variables & persisted', async (t) => {
     }
   })
 
-  t.same(JSON.parse(res2.body), {
+  t.assert.deepEqual(JSON.parse(res2.body), {
     data: {
       add: 4
     }
@@ -686,7 +686,7 @@ test('preparedOnly POST route with query, variables & persisted', async (t) => {
     }
   })
 
-  t.same(JSON.parse(res3.body), {
+  t.assert.deepEqual(JSON.parse(res3.body), {
     data: {
       add: 6
     }
@@ -719,7 +719,7 @@ test('preparedOnly reject unknown queries with 400 for GET route', async (t) => 
     url: '/graphql?query={add(x:2,y:2)}' // custom/unknown query
   })
 
-  t.equal(res.statusCode, 400)
+  t.assert.strictEqual(res.statusCode, 400)
 })
 
 test('preparedOnly reject unknown queries with 400 for POST route', async (t) => {
@@ -750,7 +750,7 @@ test('preparedOnly reject unknown queries with 400 for POST route', async (t) =>
     }
   })
 
-  t.equal(res.statusCode, 400)
+  t.assert.strictEqual(res.statusCode, 400)
 })
 
 // persistedQueries
@@ -782,7 +782,7 @@ test('persistedQueries GET route with query, variables & persisted', async (t) =
     url: '/graphql?query=248eb276edb4f22aced0a2848c539810b55f79d89abc531b91145e76838f5602&persisted=true'
   })
 
-  t.same(JSON.parse(res1.body), {
+  t.assert.deepEqual(JSON.parse(res1.body), {
     data: {
       add: 2
     }
@@ -793,7 +793,7 @@ test('persistedQueries GET route with query, variables & persisted', async (t) =
     url: '/graphql?query=495ccd73abc8436544cfeedd65f24beee660d2c7be2c32536e3fbf911f935ddf&variables={"x":2,"y":2}&persisted=true'
   })
 
-  t.same(JSON.parse(res2.body), {
+  t.assert.deepEqual(JSON.parse(res2.body), {
     data: {
       add: 4
     }
@@ -804,7 +804,7 @@ test('persistedQueries GET route with query, variables & persisted', async (t) =
     url: '/graphql?query=03ec1635d1a0ea530672bf33f28f3533239a5a7021567840c541c31d5e28c65e&persisted=true'
   })
 
-  t.same(JSON.parse(res3.body), {
+  t.assert.deepEqual(JSON.parse(res3.body), {
     data: {
       add: 6
     }
@@ -842,7 +842,7 @@ test('persistedQueries POST route with query, variables & persisted', async (t) 
     }
   })
 
-  t.same(JSON.parse(res1.body), {
+  t.assert.deepEqual(JSON.parse(res1.body), {
     data: {
       add: 2
     }
@@ -858,7 +858,7 @@ test('persistedQueries POST route with query, variables & persisted', async (t) 
     }
   })
 
-  t.same(JSON.parse(res2.body), {
+  t.assert.deepEqual(JSON.parse(res2.body), {
     data: {
       add: 4
     }
@@ -873,7 +873,7 @@ test('persistedQueries POST route with query, variables & persisted', async (t) 
     }
   })
 
-  t.same(JSON.parse(res3.body), {
+  t.assert.deepEqual(JSON.parse(res3.body), {
     data: {
       add: 6
     }
@@ -912,7 +912,7 @@ test('onlyPersisted POST route with query, variables & persisted', async (t) => 
     }
   })
 
-  t.same(JSON.parse(res1.body), {
+  t.assert.deepEqual(JSON.parse(res1.body), {
     data: {
       add: 2
     }
@@ -928,7 +928,7 @@ test('onlyPersisted POST route with query, variables & persisted', async (t) => 
     }
   })
 
-  t.same(JSON.parse(res2.body), {
+  t.assert.deepEqual(JSON.parse(res2.body), {
     data: {
       add: 4
     }
@@ -943,7 +943,7 @@ test('onlyPersisted POST route with query, variables & persisted', async (t) => 
     }
   })
 
-  t.same(JSON.parse(res3.body), {
+  t.assert.deepEqual(JSON.parse(res3.body), {
     data: {
       add: 6
     }
@@ -977,7 +977,7 @@ test('onlyPersisted reject unknown queries with 400 for GET route', async (t) =>
     url: '/graphql?query={add(x:2,y:2)}' // custom/unknown query
   })
 
-  t.equal(res.statusCode, 400)
+  t.assert.strictEqual(res.statusCode, 400)
 })
 
 test('onlyPersisted reject unknown queries with 400 for POST route', async (t) => {
@@ -1009,5 +1009,5 @@ test('onlyPersisted reject unknown queries with 400 for POST route', async (t) =
     }
   })
 
-  t.equal(res.statusCode, 400)
+  t.assert.strictEqual(res.statusCode, 400)
 })


### PR DESCRIPTION
Proposals:

  - migrated `persisted.test.js` from `tap` to `node:test` 🔥
  - added prefix `.test` 🔥