### PR TITLE
test: migrated tests from tap to node:test

### DIFF
--- a/test/disable-instrospection.test.js
+++ b/test/disable-instrospection.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const Fastify = require('fastify')
 const mercurius = require('..')
 const graphql = require('graphql')
@@ -34,7 +34,13 @@ test('should disallow instrospection with "__schema" when NoSchemaIntrospectionC
 
   // needed so that graphql is defined
   await app.ready()
-  await t.rejects(app.graphql(query), { errors: [{ message: 'GraphQL introspection has been disabled, but the requested query contained the field "__schema".' }] })
+  await t.assert.rejects(
+    app.graphql(query),
+    (err) => {
+      t.assert.strictEqual(err.errors[0].message, 'GraphQL introspection has been disabled, but the requested query contained the field "__schema".')
+      return true
+    }
+  )
 })
 
 test('should disallow instrospection with "__type" when NoSchemaIntrospectionCustomRule are applied to validationRules', async (t) => {
@@ -51,5 +57,11 @@ test('should disallow instrospection with "__type" when NoSchemaIntrospectionCus
 
   // needed so that graphql is defined
   await app.ready()
-  await t.rejects(app.graphql(query), { errors: [{ message: 'GraphQL introspection has been disabled, but the requested query contained the field "__type".' }] })
+  await t.assert.rejects(app.graphql(query), (err) => {
+    t.assert.strictEqual(
+      err.errors[0].message,
+      'GraphQL introspection has been disabled, but the requested query contained the field "__type".'
+    )
+    return true
+  })
 })

--- a/test/graphql-option-override.test.js
+++ b/test/graphql-option-override.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const Fastify = require('fastify')
 const mercurius = require('..')
 
@@ -45,7 +45,7 @@ const query2 = `{
 
 test('do not override graphql function options', async t => {
   const app = Fastify()
-  t.teardown(() => app.close())
+  t.after(() => app.close())
 
   await app.register(mercurius, {
     schema,
@@ -65,12 +65,12 @@ test('do not override graphql function options', async t => {
     }
   }
 
-  t.same(res, expectedResult)
+  t.assert.deepEqual(res, expectedResult)
 })
 
 test('override graphql.parse options', async t => {
   const app = Fastify()
-  t.teardown(() => app.close())
+  t.after(() => app.close())
 
   await app.register(mercurius, {
     schema,
@@ -90,12 +90,12 @@ test('override graphql.parse options', async t => {
     }]
   }
 
-  await t.rejects(app.graphql(query), expectedErr)
+  await t.assert.rejects(app.graphql(query), expectedErr.errors[0].message)
 })
 
 test('do not override graphql.validate options', async t => {
   const app = Fastify()
-  t.teardown(() => app.close())
+  t.after(() => app.close())
 
   await app.register(mercurius, {
     schema,
@@ -112,12 +112,12 @@ test('do not override graphql.validate options', async t => {
     ]
   }
 
-  await t.rejects(app.graphql(query2), expectedErr)
+  await t.assert.rejects(app.graphql(query2), expectedErr.errors[0].message)
 })
 
 test('override graphql.validate options', async t => {
   const app = Fastify()
-  t.teardown(() => app.close())
+  t.after(() => app.close())
 
   await app.register(mercurius, {
     schema,
@@ -138,5 +138,5 @@ test('override graphql.validate options', async t => {
     ]
   }
 
-  await t.rejects(app.graphql(query2), expectedErr)
+  await t.assert.rejects(app.graphql(query2), expectedErr.errors[0].message)
 })

--- a/test/hooks-with-batching.test.js
+++ b/test/hooks-with-batching.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const Fastify = require('fastify')
 const sinon = require('sinon')
 const GQL = require('..')

--- a/test/plugin-definition.test.js
+++ b/test/plugin-definition.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const fp = require('fastify-plugin')
 const Fastify = require('fastify')
 const GQL = require('..')
@@ -17,5 +17,10 @@ test('plugin name definition', async (t) => {
     dependencies: ['mercurius']
   }))
 
-  t.resolves(app.ready())
+  try {
+    await app.ready()
+    t.assert.ok('Fastify app is ready and plugins loaded successfully')
+  } catch (err) {
+    t.assert.fail(`App failed to be ready: ${err.message}`)
+  }
 })

--- a/test/subscriber.test.js
+++ b/test/subscriber.test.js
@@ -1,11 +1,11 @@
-const { test } = require('tap')
+const { test } = require('node:test')
 const mq = require('mqemitter')
 const { PubSub, SubscriptionContext } = require('../lib/subscriber')
 
 test('subscriber published an event', async (t) => {
   class MyQueue {
     push (value) {
-      t.equal(value, 1)
+      t.assert.strictEqual(value, 1)
     }
   }
 
@@ -15,7 +15,7 @@ test('subscriber published an event', async (t) => {
     topic: 'TOPIC',
     payload: 1
   }, () => {
-    t.pass()
+    t.assert.ok('passed')
   })
 })
 
@@ -26,7 +26,7 @@ test('subscription context not throw error on close', t => {
   const sc = new SubscriptionContext({ pubsub })
 
   sc.close()
-  t.pass()
+  t.assert.ok('passed')
 })
 
 test('subscription context publish event returns a promise', t => {
@@ -40,7 +40,7 @@ test('subscription context publish event returns a promise', t => {
     topic: 'TOPIC',
     payload: 1
   }).then(() => {
-    t.pass()
+    t.assert.ok('passed')
   })
 })
 
@@ -52,7 +52,7 @@ test('subscription context publish event errs, error is catched', t => {
   const fastifyMock = {
     log: {
       error () {
-        t.pass()
+        t.assert.ok('passed')
       }
     }
   }
@@ -74,31 +74,25 @@ test('subscription context publish event returns a promise reject on error', asy
   const pubsub = new PubSub(emitter)
   const sc = new SubscriptionContext({ pubsub })
 
-  await t.rejects(sc.subscribe('TOPIC'), error)
+  await t.assert.rejects(sc.subscribe('TOPIC'), error)
 })
 
-test('subscription context can handle multiple topics', t => {
-  t.plan(4)
-
+test('subscription context can handle multiple topics', async (t) => {
   const q = mq()
   const pubsub = new PubSub(q)
   const sc = new SubscriptionContext({ pubsub })
 
   sc.subscribe(['TOPIC1', 'TOPIC2'])
-  sc.publish({
+  await sc.publish({
     topic: 'TOPIC1',
     payload: 1
-  }).then(() => {
-    t.pass()
   })
-  sc.publish({
+  await sc.publish({
     topic: 'TOPIC2',
     payload: 2
-  }).then(() => {
-    t.pass()
   })
 
-  t.equal(q._matcher._trie.size, 2, 'Two listeners not found')
+  t.assert.strictEqual(q._matcher._trie.size, 2, 'Two listeners not found')
   sc.close()
-  setImmediate(() => { t.equal(q._matcher._trie.size, 0, 'All listeners not removed') })
+  setImmediate(() => { t.assert.strictEqual(q._matcher._trie.size, 0, 'All listeners not removed') })
 })

--- a/test/subscription-protocol.test.js
+++ b/test/subscription-protocol.test.js
@@ -1,10 +1,10 @@
 'use strict'
-const { test } = require('tap')
+const { test } = require('node:test')
 const { getProtocolByName } = require('../lib/subscription-protocol')
 
 test('getProtocolByName returns correct protocol message types', t => {
   t.plan(3)
-  t.same(getProtocolByName('graphql-ws'), {
+  t.assert.deepStrictEqual(getProtocolByName('graphql-ws'), {
     GQL_CONNECTION_INIT: 'connection_init',
     GQL_CONNECTION_ACK: 'connection_ack',
     GQL_CONNECTION_ERROR: 'connection_error',
@@ -16,7 +16,7 @@ test('getProtocolByName returns correct protocol message types', t => {
     GQL_COMPLETE: 'complete',
     GQL_STOP: 'stop'
   })
-  t.same(getProtocolByName('graphql-transport-ws'), {
+  t.assert.deepStrictEqual(getProtocolByName('graphql-transport-ws'), {
     GQL_CONNECTION_INIT: 'connection_init',
     GQL_CONNECTION_ACK: 'connection_ack',
     GQL_CONNECTION_ERROR: 'connection_error',
@@ -29,5 +29,5 @@ test('getProtocolByName returns correct protocol message types', t => {
     GQL_COMPLETE: 'complete',
     GQL_STOP: 'complete'
   })
-  t.equal(getProtocolByName('unsupported-protocol'), null)
+  t.assert.deepStrictEqual(getProtocolByName('unsupported-protocol'), null)
 })


### PR DESCRIPTION
Proposals:

  - migrated `disable-instrospection.test.js` from `tap` to `node:test` 🔥
  - migrated `hooks-with-batching.test.js` from `tap` to `node:test` 🔥
  - migrated `plugin-definition.test.js` from `tap` to `node:test` 🔥
  - migrated `subscription-protocol.test.js` from `tap` to `node:test` 🔥
  - migrated `graphql-option-override.js`from `tap` to `node:test` 🔥
  - migrated `subscriber.test.js` from `tap` to `node:test` 🔥
  - added prefix `.test`  🔥

I have grouped some tests in this PR, since I am very easy to review 😉