### PR TITLE
test: migrated hooks-runner.test.js from tap to node:test

### DIFF
--- a/test/errors.js
+++ b/test/errors.js
@@ -891,7 +891,7 @@ test('bad json', async (t) => {
   t.equal(res.statusCode, 400)
   if (semver.gte(process.version, '20.0.0')) {
     t.same(res.json(),
-      { data: null, errors: [{ message: 'Unexpected token \'h\', "this is not a json" is not valid JSON' }] }
+      { data: null, errors: [{ message: "Body is not valid JSON but content-type is set to 'application/json'" }] }
     )
   } else {
     t.same(res.json(),

--- a/test/internals/hooks-runner.test.js
+++ b/test/internals/hooks-runner.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const { hooksRunner, preExecutionHooksRunner } = require('../../lib/hooks')
 
 test('hooksRunner - Basic', (t) => {
@@ -13,17 +13,17 @@ test('hooksRunner - Basic', (t) => {
   }
 
   function fn1 (a) {
-    t.equal(a, 'a')
+    t.assert.strictEqual(a, 'a')
     return Promise.resolve()
   }
 
   function fn2 (a) {
-    t.equal(a, 'a')
+    t.assert.strictEqual(a, 'a')
     return Promise.resolve()
   }
 
   function fn3 (a) {
-    t.equal(a, 'a')
+    t.assert.strictEqual(a, 'a')
     return Promise.resolve()
   }
 })
@@ -31,24 +31,24 @@ test('hooksRunner - Basic', (t) => {
 test('hooksRunner - In case of error should skip subsequent functions', async (t) => {
   t.plan(3)
 
-  await t.rejects(hooksRunner([fn1, fn2, fn3], iterator, 'a'), { message: 'kaboom' })
+  await t.assert.rejects(hooksRunner([fn1, fn2, fn3], iterator, 'a'), { message: 'kaboom' })
 
   function iterator (fn, a) {
     return fn(a)
   }
 
   function fn1 (a) {
-    t.equal(a, 'a')
+    t.assert.strictEqual(a, 'a')
     return Promise.resolve()
   }
 
   function fn2 (a) {
-    t.equal(a, 'a')
+    t.assert.strictEqual(a, 'a')
     return Promise.reject(new Error('kaboom'))
   }
 
   function fn3 () {
-    t.fail('We should not be here')
+    t.assert.fail('We should not be here')
   }
 })
 
@@ -67,18 +67,18 @@ test('hooksRunner - Be able to exit before its natural end', async (t) => {
   }
 
   function fn1 (a) {
-    t.equal(a, 'a')
+    t.assert.strictEqual(a, 'a')
     return Promise.resolve()
   }
 
   function fn2 (a) {
-    t.equal(a, 'a')
+    t.assert.strictEqual(a, 'a')
     shouldStop = true
     return Promise.resolve()
   }
 
   function fn3 () {
-    t.fail('this should not be called')
+    t.assert.fail('this should not be called')
   }
 })
 
@@ -94,38 +94,38 @@ test('hooksRunner - Promises that resolve to a value do not change the state', (
   }
 
   function fn1 (state) {
-    t.equal(state, originalState)
+    t.assert.strictEqual(state, originalState)
     return Promise.resolve(null)
   }
 
   function fn2 (state) {
-    t.equal(state, originalState)
+    t.assert.strictEqual(state, originalState)
     return Promise.resolve('string')
   }
 
   function fn3 (state) {
-    t.equal(state, originalState)
+    t.assert.strictEqual(state, originalState)
     return Promise.resolve({ object: true })
   }
 
   function fn4 (state) {
-    t.equal(state, originalState)
+    t.assert.strictEqual(state, originalState)
   }
 })
 
 test('hooksRunner - Should handle when iterator errors', async (t) => {
-  await t.rejects(hooksRunner([fn1, fn2], iterator, 'a'), { message: 'kaboom' })
+  await t.assert.rejects(hooksRunner([fn1, fn2], iterator, 'a'), { message: 'kaboom' })
 
   function iterator (fn) {
     throw new Error('kaboom')
   }
 
   function fn1 () {
-    t.fail('We should not be here')
+    t.assert.fail('We should not be here')
   }
 
   function fn2 () {
-    t.fail('We should not be here')
+    t.assert.fail('We should not be here')
   }
 })
 
@@ -137,23 +137,23 @@ test('preExecutionHooksRunner - Basic', (t) => {
   preExecutionHooksRunner([fn1, fn2, fn3], originalRequest)
 
   function fn1 (schema, document, context) {
-    t.equal(schema, 'schema')
-    t.equal(document, 'document')
-    t.equal(context, 'context')
+    t.assert.strictEqual(schema, 'schema')
+    t.assert.strictEqual(document, 'document')
+    t.assert.strictEqual(context, 'context')
     return Promise.resolve()
   }
 
   function fn2 (schema, document, context) {
-    t.equal(schema, 'schema')
-    t.equal(document, 'document')
-    t.equal(context, 'context')
+    t.assert.strictEqual(schema, 'schema')
+    t.assert.strictEqual(document, 'document')
+    t.assert.strictEqual(context, 'context')
     return Promise.resolve()
   }
 
   function fn3 (schema, document, context) {
-    t.equal(schema, 'schema')
-    t.equal(document, 'document')
-    t.equal(context, 'context')
+    t.assert.strictEqual(schema, 'schema')
+    t.assert.strictEqual(document, 'document')
+    t.assert.strictEqual(context, 'context')
     return Promise.resolve()
   }
 })
@@ -162,24 +162,24 @@ test('preExecutionHooksRunner - In case of error should skip subsequent function
   t.plan(7)
 
   const originalRequest = { schema: 'schema', document: 'document', context: 'context' }
-  await t.rejects(preExecutionHooksRunner([fn1, fn2, fn3], originalRequest), { message: 'kaboom' })
+  await t.assert.rejects(preExecutionHooksRunner([fn1, fn2, fn3], originalRequest), { message: 'kaboom' })
 
   function fn1 (schema, document, context) {
-    t.equal(schema, 'schema')
-    t.equal(document, 'document')
-    t.equal(context, 'context')
+    t.assert.strictEqual(schema, 'schema')
+    t.assert.strictEqual(document, 'document')
+    t.assert.strictEqual(context, 'context')
     return Promise.resolve()
   }
 
   function fn2 (schema, document, context) {
-    t.equal(schema, 'schema')
-    t.equal(document, 'document')
-    t.equal(context, 'context')
+    t.assert.strictEqual(schema, 'schema')
+    t.assert.strictEqual(document, 'document')
+    t.assert.strictEqual(context, 'context')
     return Promise.reject(new Error('kaboom'))
   }
 
   function fn3 (schema, document, context) {
-    t.fail('We should not be here')
+    t.assert.fail('We should not be here')
   }
 })
 
@@ -191,27 +191,27 @@ test('preExecutionHooksRunner - Promises that resolve to a value do not change t
   await preExecutionHooksRunner([fn1, fn2, fn3], originalRequest)
 
   function fn1 (schema, document, context) {
-    t.equal(schema, 'schema')
-    t.equal(document, 'document')
-    t.equal(context, 'context')
+    t.assert.strictEqual(schema, 'schema')
+    t.assert.strictEqual(document, 'document')
+    t.assert.strictEqual(context, 'context')
     return Promise.resolve(null)
   }
 
   function fn2 (schema, document, context) {
-    t.equal(schema, 'schema')
-    t.equal(document, 'document')
-    t.equal(context, 'context')
+    t.assert.strictEqual(schema, 'schema')
+    t.assert.strictEqual(document, 'document')
+    t.assert.strictEqual(context, 'context')
     return Promise.resolve('string')
   }
 
   function fn3 (schema, document, context) {
-    t.equal(schema, 'schema')
-    t.equal(document, 'document')
-    t.equal(context, 'context')
+    t.assert.strictEqual(schema, 'schema')
+    t.assert.strictEqual(document, 'document')
+    t.assert.strictEqual(context, 'context')
     return Promise.resolve({ object: true })
   }
 
-  t.same(originalRequest, { schema: 'schema', document: 'document', context: 'context' })
+  t.assert.deepStrictEqual(originalRequest, { schema: 'schema', document: 'document', context: 'context' })
 })
 
 test('preExecutionHooksRunner - Promises can modify a query document', async (t) => {
@@ -222,14 +222,14 @@ test('preExecutionHooksRunner - Promises can modify a query document', async (t)
   const { modifiedDocument } = await preExecutionHooksRunner([fn1], originalRequest)
 
   function fn1 (schema, document, context) {
-    t.equal(schema, 'schema')
-    t.same(document, { old: 'old' })
-    t.equal(context, 'context')
+    t.assert.strictEqual(schema, 'schema')
+    t.assert.deepStrictEqual(document, { old: 'old' })
+    t.assert.strictEqual(context, 'context')
     return Promise.resolve({ document: { new: 'new' } })
   }
 
-  t.same(originalRequest, { schema: 'schema', document: { old: 'old' }, context: 'context' })
-  t.same(modifiedDocument, { new: 'new' })
+  t.assert.deepStrictEqual(originalRequest, { schema: 'schema', document: { old: 'old' }, context: 'context' })
+  t.assert.deepStrictEqual(modifiedDocument, { new: 'new' })
 })
 
 test('preExecutionHooksRunner - Promises can add to existing execution errors', async (t) => {
@@ -240,39 +240,39 @@ test('preExecutionHooksRunner - Promises can add to existing execution errors', 
   const { errors } = await preExecutionHooksRunner([fn1], originalRequest)
 
   function fn1 (schema, document, context) {
-    t.equal(schema, 'schema')
-    t.equal(document, 'document')
-    t.equal(context, 'context')
+    t.assert.strictEqual(schema, 'schema')
+    t.assert.strictEqual(document, 'document')
+    t.assert.strictEqual(context, 'context')
     return Promise.resolve({ errors: [{ message: 'new errors' }] })
   }
 
-  t.same(originalRequest, { schema: 'schema', document: 'document', context: 'context' })
-  t.same(errors, [{ message: 'new errors' }])
+  t.assert.deepStrictEqual(originalRequest, { schema: 'schema', document: 'document', context: 'context' })
+  t.assert.deepStrictEqual(errors, [{ message: 'new errors' }])
 })
 
 test('preExecutionHooksRunner - Should handle thrown errors', async t => {
   t.plan(8)
 
   const originalRequest = { schema: 'schema', document: 'document', context: 'context' }
-  await t.rejects(preExecutionHooksRunner([fn1, fn2, fn3], originalRequest), { message: 'kaboom' })
-  t.same(originalRequest, { schema: 'schema', document: 'document', context: 'context' })
+  await t.assert.rejects(preExecutionHooksRunner([fn1, fn2, fn3], originalRequest), { message: 'kaboom' })
+  t.assert.deepStrictEqual(originalRequest, { schema: 'schema', document: 'document', context: 'context' })
 
   function fn1 (schema, document, context) {
-    t.equal(schema, 'schema')
-    t.equal(document, 'document')
-    t.equal(context, 'context')
+    t.assert.strictEqual(schema, 'schema')
+    t.assert.strictEqual(document, 'document')
+    t.assert.strictEqual(context, 'context')
     return Promise.resolve()
   }
 
   function fn2 (schema, document, context) {
-    t.equal(schema, 'schema')
-    t.equal(document, 'document')
-    t.equal(context, 'context')
+    t.assert.strictEqual(schema, 'schema')
+    t.assert.strictEqual(document, 'document')
+    t.assert.strictEqual(context, 'context')
     throw new Error('kaboom')
   }
 
   function fn3 () {
-    t.fail('We should not be here')
+    t.assert.fail('We should not be here')
   }
 })
 
@@ -284,16 +284,16 @@ test('preExecutionHooksRunner - Should handle non promise functions ', async t =
   await preExecutionHooksRunner([fn1, fn2], originalRequest)
 
   function fn1 (schema, document, context) {
-    t.equal(schema, 'schema')
-    t.equal(document, 'document')
-    t.equal(context, 'context')
+    t.assert.strictEqual(schema, 'schema')
+    t.assert.strictEqual(document, 'document')
+    t.assert.strictEqual(context, 'context')
     return Promise.resolve()
   }
 
   function fn2 (schema, document, context) {
-    t.equal(schema, 'schema')
-    t.equal(document, 'document')
-    t.equal(context, 'context')
+    t.assert.strictEqual(schema, 'schema')
+    t.assert.strictEqual(document, 'document')
+    t.assert.strictEqual(context, 'context')
   }
-  t.same(originalRequest, { schema: 'schema', document: 'document', context: 'context' })
+  t.assert.deepStrictEqual(originalRequest, { schema: 'schema', document: 'document', context: 'context' })
 })


### PR DESCRIPTION
Proposals:

- migrated `hooks-runner.test.js` from `tap` to `node:test` 🔥
- added prefix `.test` 🔥
- renamed file in `kebab-case` 🔥
- fixed problem with `errors.js` test 🔥 ( Fix Pipeline CI )
