### PR TITLE
check socket before awaiting subscription iterator

### DIFF
--- a/lib/subscription-connection.js
+++ b/lib/subscription-connection.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const WebSocket = require('ws')
 const { on } = require('events')
 const { subscribe, parse, print, getOperationAST } = require('graphql')
 const { SubscriptionContext } = require('./subscriber')
@@ -318,6 +319,15 @@ module.exports = class SubscriptionConnection {
       variableValues: variables,
       operationName
     })
+
+    // If the socket closed while we were awaiting subscribe(), clean up the
+    // iterator immediately and exit. Otherwise the iterator would be orphaned
+    // since handleConnectionClose() already ran before we could add it to the map.
+    if (this.socket.readyState !== WebSocket.OPEN) {
+      subIter.return && subIter.return()
+      return
+    }
+
     this.subscriptionIters.set(id, subIter)
 
     if (subIter.errors) {


### PR DESCRIPTION
If the socket closes while we are awaiting subscribe() the iterator becomes orphaned since handleConnectionClose() has already run before we could add it to the map. This leads to a memory leak as the iterators are never cleaned up.
