### PR TITLE
replace p-map with tiny-pmap

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "fastify-plugin": "^5.0.0",
     "graphql-jit": "0.8.7",
     "mqemitter": "^7.0.0",
-    "p-map": "^4.0.0",
+    "tiny-pmap": "^1.0.0",
     "quick-lru": "^7.0.0",
     "readable-stream": "^4.0.0",
     "safe-stable-stringify": "^2.3.0",


### PR DESCRIPTION
p-map v4 has no TypeScript types. The current version (v7) is ESM-only.

tiny-pmap has the same API, ships ESM + CJS with built-in types. Zero deps.

https://npmgraph.js.org/?q=tiny-pmap