### PR TITLE
fix: Add SubscriptionContext type to correctly type context.pubsub in subscription resolvers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -54,6 +54,43 @@ declare namespace mercurius {
     ): void;
   }
 
+  export interface SubscriptionContext {
+    /**
+     * The underlying pubsub implementation (either default PubSub or custom implementation)
+     */
+    pubsub: PubSub | CustomPubSub;
+    /**
+     * Fastify application instance
+     */
+    fastify: FastifyInstance;
+    /**
+     * Readable stream for subscription data
+     */
+    queue: Readable;
+    /**
+     * Whether the subscription context is closed
+     */
+    closed: boolean;
+    /**
+     * Subscribe to a topic or topics
+     * @param topics - A single topic or array of topics to subscribe to
+     * @param customArgs - Additional arguments passed to custom pubsub implementations
+     * @returns A readable stream that emits subscription data
+     */
+    subscribe<T = any>(topics: string | string[], ...customArgs: any[]): Promise<Readable & AsyncIterableIterator<T>>;
+    /**
+     * Publish an event to the pubsub
+     * @param event - The event to publish with topic and payload
+     * @returns Promise that resolves when the event is published
+     */
+    publish(event: { topic: string; payload: any }): Promise<void>;
+    /**
+     * Close the subscription context and cleanup resources
+     * @returns true if closed successfully, false if already closed
+     */
+    close(): boolean;
+  }
+
   export interface MercuriusContext {
     app: FastifyInstance;
     reply: FastifyReply;
@@ -63,7 +100,7 @@ declare namespace mercurius {
     /**
      * __Caution__: Only available if `subscriptions` are enabled
      */
-    pubsub: PubSub;
+    pubsub: SubscriptionContext;
   }
 
   export interface MercuriusError<TError extends Error = Error> extends FastifyError {
@@ -544,7 +581,11 @@ declare namespace mercurius {
       | boolean
       | {
         emitter?: object;
-        pubsub?: any; // FIXME: Technically this should be the PubSub type. But PubSub is now typed as SubscriptionContext.
+        /**
+         * A custom pubsub implementation. When provided, this will be used instead of the default PubSub.
+         * The custom implementation must follow the CustomPubSub interface.
+         */
+        pubsub?: CustomPubSub;
         verifyClient?: (
           info: { origin: string; secure: boolean; req: IncomingMessage },
           next: (

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -16,7 +16,9 @@ import mercurius, {
   MercuriusContext,
   MercuriusPlugin,
   MercuriusLoaders,
-  CustomPubSub
+  CustomPubSub,
+  SubscriptionContext,
+  PubSub
 } from '../..'
 import { DocumentNode, ExecutionResult, GraphQLSchema, ValidationContext, ValidationRule } from 'graphql'
 import { mapSchema } from '@graphql-tools/utils'
@@ -728,3 +730,234 @@ expectError(app.register(mercurius, {
     },
   }
 }))
+
+// Issue #350: PubSub, SubscriptionContext and types
+// https://github.com/mercurius-js/mercurius/issues/350
+
+// Test that app.graphql.pubsub is typed as PubSub
+app.register(mercurius, {
+  schema,
+  resolvers,
+  subscription: true
+})
+
+app.graphql.pubsub.publish({
+  topic: 'topic',
+  payload: 'payload'
+})
+
+app.graphql.pubsub.subscribe('topic')
+  .then((sub) => {
+    sub.on('data', (chunk) => {
+      console.log(chunk)
+    })
+  })
+
+// Test that subscription.pubsub option accepts CustomPubSub
+app.register(mercurius, {
+  schema,
+  resolvers,
+  subscription: {
+    pubsub: new CustomPubSubImpl()
+  }
+})
+
+// Test that context.pubsub in subscription resolvers is typed as SubscriptionContext
+// and has the correct methods (subscribe, publish, close)
+app.register(mercurius, {
+  schema: `
+    type Subscription {
+      newDogs: Dog
+    }
+    type Dog {
+      name: String
+    }
+  `,
+  resolvers: {
+    Subscription: {
+      newDogs: {
+        subscribe: async (_root, _args, context) => {
+          // context.pubsub should be SubscriptionContext in subscription resolvers
+          const sub = await context.pubsub.subscribe('new_dog')
+          sub.on('data', (chunk) => {
+            console.log(chunk)
+          })
+          return sub
+        }
+      }
+    }
+  },
+  subscription: true
+})
+
+// Test that withFilter receives SubscriptionContext in subscription resolvers
+app.register(mercurius, {
+  schema: `
+    type Subscription {
+      newDogs: Dog
+    }
+    type Dog {
+      name: String
+      breed: String
+    }
+  `,
+  resolvers: {
+    Subscription: {
+      newDogs: {
+        subscribe: withFilter(
+          async (_root, _args, context) => {
+            // context.pubsub should be SubscriptionContext
+            return context.pubsub.subscribe('new_dog')
+          },
+          (payload, _args, context) => {
+            // context should have pubsub
+            context.pubsub
+            return true
+          }
+        )
+      }
+    }
+  },
+  subscription: true
+})
+
+// Test that onDisconnect hook receives MercuriusContext with SubscriptionContext pubsub
+app.register(mercurius, {
+  schema,
+  resolvers,
+  subscription: {
+    onDisconnect: (context) => {
+      // context.pubsub should be SubscriptionContext
+      context.pubsub
+    }
+  }
+})
+
+// Test that subscription context pubsub has different signature than app.graphql.pubsub
+app.register(mercurius, {
+  schema: `
+    type Subscription {
+      test: String
+    }
+  `,
+  resolvers: {
+    Subscription: {
+      test: {
+        subscribe: async (_root, _args, context) => {
+          // In subscription resolvers, context.pubsub should have:
+          // - subscribe(topics): Promise<Readable>
+          // - publish(event): Promise<void>
+          // - close(): boolean
+          const sub = await context.pubsub.subscribe('test')
+          return sub
+        }
+      }
+    }
+  },
+  subscription: true
+})
+
+// Test that app.graphql.pubsub has:
+// - subscribe(topics): Promise<Readable & AsyncIterableIterator>
+// - publish(event, callback?): void
+app.graphql.pubsub.publish({
+  topic: 'test',
+  payload: 'test'
+})
+app.graphql.pubsub.publish({
+  topic: 'test',
+  payload: 'test'
+}, () => {
+  console.log('published')
+})
+
+// Issue #350: context.pubsub in subscription resolvers has a nested pubsub property
+// that contains the actual pubsub implementation
+app.register(mercurius, {
+  schema: `
+    type Subscription {
+      test: String
+    }
+  `,
+  resolvers: {
+    Subscription: {
+      test: {
+        subscribe: async (_root, _args, context) => {
+          // context.pubsub is SubscriptionContext
+          // context.pubsub.pubsub is the underlying PubSub or CustomPubSub
+          context.pubsub.pubsub
+          context.pubsub.fastify
+          context.pubsub.queue
+          context.pubsub.close()
+          return await context.pubsub.subscribe('test')
+        }
+      }
+    }
+  },
+  subscription: true
+})
+
+// Test that SubscriptionContext can be imported and used
+function testSubscriptionContextType (_ctx: SubscriptionContext) {
+  _ctx.pubsub
+  _ctx.fastify
+  _ctx.queue
+  _ctx.closed
+  _ctx.subscribe('test')
+  _ctx.publish({ topic: 'test', payload: 'test' })
+  _ctx.close()
+}
+
+testSubscriptionContextType({} as SubscriptionContext)
+
+// Test the full scenario from issue #350:
+// When using a custom pubsub implementation:
+// - app.graphql.pubsub is the custom pubsub (CustomPubSub)
+// - context.pubsub in subscription resolvers is SubscriptionContext
+// - context.pubsub.pubsub is the custom pubsub (CustomPubSub)
+
+class MyCustomPubSub implements CustomPubSub {
+  emitter: EventEmitter
+  constructor () {
+    this.emitter = new EventEmitter()
+  }
+
+  async subscribe (topic: string | string[], queue: Readable & { close: () => void }): Promise<void> {
+    // custom implementation
+  }
+
+  publish (event: { topic: string, payload: any }, callback: () => void): void {
+    // custom implementation
+  }
+}
+
+const customPubSub = new MyCustomPubSub()
+
+app.register(mercurius, {
+  schema: `
+    type Subscription {
+      test: String
+    }
+  `,
+  resolvers: {
+    Subscription: {
+      test: {
+        subscribe: async (_root, _args, context) => {
+          // context.pubsub is SubscriptionContext
+          expectType<SubscriptionContext>(context.pubsub)
+
+          // context.pubsub.pubsub is the custom pubsub
+          expectType<PubSub | CustomPubSub>(context.pubsub.pubsub)
+
+          return await context.pubsub.subscribe('test')
+        }
+      }
+    }
+  },
+  subscription: {
+    pubsub: customPubSub
+  }
+})
+
+// app.graphql.pubsub should be the custom pubsub
+app.graphql.pubsub.publish({ topic: 'test', payload: 'test' })

--- a/test/types/index.tst.ts
+++ b/test/types/index.tst.ts
@@ -16,7 +16,9 @@ import mercurius, {
   MercuriusContext,
   MercuriusPlugin,
   MercuriusLoaders,
-  CustomPubSub
+  CustomPubSub,
+  SubscriptionContext,
+  PubSub
 } from '../..'
 import { DocumentNode, ExecutionResult, GraphQLSchema, ValidationContext, ValidationRule } from 'graphql'
 import { mapSchema } from '@graphql-tools/utils'
@@ -709,3 +711,234 @@ expect(app.register).type.not.toBeCallableWith(mercurius, {
     }
   }
 })
+
+// Issue #350: PubSub, SubscriptionContext and types
+// https://github.com/mercurius-js/mercurius/issues/350
+
+// Test that app.graphql.pubsub is typed as PubSub
+app.register(mercurius, {
+  schema,
+  resolvers,
+  subscription: true
+})
+
+app.graphql.pubsub.publish({
+  topic: 'topic',
+  payload: 'payload'
+})
+
+app.graphql.pubsub.subscribe('topic')
+  .then((sub) => {
+    sub.on('data', (chunk) => {
+      console.log(chunk)
+    })
+  })
+
+// Test that subscription.pubsub option accepts CustomPubSub
+app.register(mercurius, {
+  schema,
+  resolvers,
+  subscription: {
+    pubsub: new CustomPubSubImpl()
+  }
+})
+
+// Test that context.pubsub in subscription resolvers is typed as SubscriptionContext
+// and has the correct methods (subscribe, publish, close)
+app.register(mercurius, {
+  schema: `
+    type Subscription {
+      newDogs: Dog
+    }
+    type Dog {
+      name: String
+    }
+  `,
+  resolvers: {
+    Subscription: {
+      newDogs: {
+        subscribe: async (_root, _args, context) => {
+          // context.pubsub should be SubscriptionContext in subscription resolvers
+          const sub = await context.pubsub.subscribe('new_dog')
+          sub.on('data', (chunk) => {
+            console.log(chunk)
+          })
+          return sub
+        }
+      }
+    }
+  },
+  subscription: true
+})
+
+// Test that withFilter receives SubscriptionContext in subscription resolvers
+app.register(mercurius, {
+  schema: `
+    type Subscription {
+      newDogs: Dog
+    }
+    type Dog {
+      name: String
+      breed: String
+    }
+  `,
+  resolvers: {
+    Subscription: {
+      newDogs: {
+        subscribe: withFilter(
+          async (_root, _args, context) => {
+            // context.pubsub should be SubscriptionContext
+            return context.pubsub.subscribe('new_dog')
+          },
+          (payload, _args, context) => {
+            // context should have pubsub
+            context.pubsub
+            return true
+          }
+        )
+      }
+    }
+  },
+  subscription: true
+})
+
+// Test that onDisconnect hook receives MercuriusContext with SubscriptionContext pubsub
+app.register(mercurius, {
+  schema,
+  resolvers,
+  subscription: {
+    onDisconnect: (context) => {
+      // context.pubsub should be SubscriptionContext
+      context.pubsub
+    }
+  }
+})
+
+// Test that subscription context pubsub has different signature than app.graphql.pubsub
+app.register(mercurius, {
+  schema: `
+    type Subscription {
+      test: String
+    }
+  `,
+  resolvers: {
+    Subscription: {
+      test: {
+        subscribe: async (_root, _args, context) => {
+          // In subscription resolvers, context.pubsub should have:
+          // - subscribe(topics): Promise<Readable>
+          // - publish(event): Promise<void>
+          // - close(): boolean
+          const sub = await context.pubsub.subscribe('test')
+          return sub
+        }
+      }
+    }
+  },
+  subscription: true
+})
+
+// Test that app.graphql.pubsub has:
+// - subscribe(topics): Promise<Readable & AsyncIterableIterator>
+// - publish(event, callback?): void
+app.graphql.pubsub.publish({
+  topic: 'test',
+  payload: 'test'
+})
+app.graphql.pubsub.publish({
+  topic: 'test',
+  payload: 'test'
+}, () => {
+  console.log('published')
+})
+
+// Issue #350: context.pubsub in subscription resolvers has a nested pubsub property
+// that contains the actual pubsub implementation
+app.register(mercurius, {
+  schema: `
+    type Subscription {
+      test: String
+    }
+  `,
+  resolvers: {
+    Subscription: {
+      test: {
+        subscribe: async (_root, _args, context) => {
+          // context.pubsub is SubscriptionContext
+          // context.pubsub.pubsub is the underlying PubSub or CustomPubSub
+          context.pubsub.pubsub
+          context.pubsub.fastify
+          context.pubsub.queue
+          context.pubsub.close()
+          return await context.pubsub.subscribe('test')
+        }
+      }
+    }
+  },
+  subscription: true
+})
+
+// Test that SubscriptionContext can be imported and used
+function testSubscriptionContextType (_ctx: SubscriptionContext) {
+  _ctx.pubsub
+  _ctx.fastify
+  _ctx.queue
+  _ctx.closed
+  _ctx.subscribe('test')
+  _ctx.publish({ topic: 'test', payload: 'test' })
+  _ctx.close()
+}
+
+testSubscriptionContextType({} as SubscriptionContext)
+
+// Test the full scenario from issue #350:
+// When using a custom pubsub implementation:
+// - app.graphql.pubsub is the custom pubsub (CustomPubSub)
+// - context.pubsub in subscription resolvers is SubscriptionContext
+// - context.pubsub.pubsub is the custom pubsub (CustomPubSub)
+
+class MyCustomPubSub implements CustomPubSub {
+  emitter: EventEmitter
+  constructor () {
+    this.emitter = new EventEmitter()
+  }
+
+  async subscribe (topic: string | string[], queue: Readable & { close: () => void }): Promise<void> {
+    // custom implementation
+  }
+
+  publish (event: { topic: string, payload: any }, callback: () => void): void {
+    // custom implementation
+  }
+}
+
+const customPubSub = new MyCustomPubSub()
+
+app.register(mercurius, {
+  schema: `
+    type Subscription {
+      test: String
+    }
+  `,
+  resolvers: {
+    Subscription: {
+      test: {
+        subscribe: async (_root, _args, context) => {
+          // context.pubsub is SubscriptionContext
+          expect(context.pubsub).type.toBe<SubscriptionContext>()
+
+          // context.pubsub.pubsub is the custom pubsub
+          expect(context.pubsub.pubsub).type.toBe<PubSub | CustomPubSub>()
+
+          return await context.pubsub.subscribe('test')
+        }
+      }
+    }
+  },
+  subscription: {
+    pubsub: customPubSub
+  }
+})
+
+// app.graphql.pubsub should be the custom pubsub
+app.graphql.pubsub.publish({ topic: 'test', payload: 'test' })


### PR DESCRIPTION
Fixes issue #350 where `context.pubsub` in subscription resolvers was typed as `PubSub`
but was actually a `SubscriptionContext` wrapper at runtime.

## Changes

### Type Definitions (`index.d.ts`)

- Added new `SubscriptionContext` interface that represents the wrapper used in
  subscription resolvers
- Updated `MercuriusContext.pubsub` to be `SubscriptionContext` instead of `PubSub`
- Fixed `FIXME` comment by typing `subscription.pubsub` option as `CustomPubSub`

### The `SubscriptionContext` interface includes:

- `pubsub: PubSub | CustomPubSub` — the underlying pubsub implementation
- `fastify: FastifyInstance` — Fastify application instance
- `queue: Readable` — Readable stream for subscription data
- `closed: boolean` — whether the subscription context is closed
- `subscribe(topics, ...customArgs)` — subscribe to topic(s)
- `publish(event)` — publish an event
- `close()` — close and cleanup resources

### Type Tests (`test/types/index.ts`)

Added comprehensive type tests that verify:

- `app.graphql.pubsub` is typed as `PubSub`
- `context.pubsub` in subscription resolvers is typed as `SubscriptionContext`
- `context.pubsub.pubsub` contains the underlying `PubSub | CustomPubSub`
- `subscription.pubsub` option accepts `CustomPubSub`
- `SubscriptionContext` can be imported and used explicitly
- The full scenario from issue #350 where users can access their custom pubsub via `context.pubsub.pubsub`

## Verification

All existing tests pass:

- `npm run lint` — no errors
- `npm run unit` — 373 tests pass
- `npm run typescript` — type tests pass
