### PR TITLE
fix: do not crash when a subscription message is delivered after the queue has ended

### DIFF
--- a/lib/subscriber.js
+++ b/lib/subscriber.js
@@ -9,14 +9,17 @@ class PubSub {
 
   subscribe (topic, queue) {
     return new Promise((resolve, reject) => {
+      // A message can be delivered after the subscription has closed:
+      // emitters with asynchronous delivery (e.g. mqemitter-redis) may have
+      // a message in flight when close() runs, and deliver it after
+      // SubscriptionContext.close() has ended the queue with push(null).
+      // Pushing after EOF emits an unhandled 'error' on the Readable and
+      // crashes the process. The subscriber is gone — drop the message.
+      // (`readableEnded` alone cannot guard this: it only becomes true once
+      // 'end' has been emitted, which may be after the late delivery.)
+      let unsubscribed = false
       function listener (value, cb) {
-        // A message can be delivered after the subscription queue has ended:
-        // emitters with asynchronous delivery (e.g. mqemitter-redis) may have
-        // a message in flight when SubscriptionContext.close() pushes null.
-        // Pushing after EOF emits an unhandled 'error' on the Readable and
-        // crashes the process. The subscriber is gone — drop the message.
-        const state = queue._readableState
-        if (queue.destroyed || (state && state.ended)) {
+        if (unsubscribed || queue.destroyed || queue.readableEnded) {
           return cb()
         }
         queue.push(value.payload)
@@ -24,6 +27,7 @@ class PubSub {
       }
 
       const close = () => {
+        unsubscribed = true
         this.emitter.removeListener(topic, listener)
       }
 

--- a/lib/subscriber.js
+++ b/lib/subscriber.js
@@ -10,6 +10,15 @@ class PubSub {
   subscribe (topic, queue) {
     return new Promise((resolve, reject) => {
       function listener (value, cb) {
+        // A message can be delivered after the subscription queue has ended:
+        // emitters with asynchronous delivery (e.g. mqemitter-redis) may have
+        // a message in flight when SubscriptionContext.close() pushes null.
+        // Pushing after EOF emits an unhandled 'error' on the Readable and
+        // crashes the process. The subscriber is gone — drop the message.
+        const state = queue._readableState
+        if (queue.destroyed || (state && state.ended)) {
+          return cb()
+        }
         queue.push(value.payload)
         cb()
       }
@@ -44,6 +53,11 @@ class SubscriptionContext {
       objectMode: true,
       highWaterMark: queueHighWaterMark,
       read: () => {}
+    })
+    // Defence in depth: an unhandled 'error' event on the queue kills the
+    // whole process. Log it and move on — the subscription is dead anyway.
+    this.queue.on('error', (err) => {
+      this.fastify?.log?.error({ err }, 'subscription queue error (suppressed)')
     })
     this.closed = false
   }

--- a/test/subscriber.test.js
+++ b/test/subscriber.test.js
@@ -112,6 +112,79 @@ test('subscription context can handle multiple topics', async (t) => {
   setImmediate(() => { t.assert.strictEqual(q._matcher._trie.size, 0, 'All listeners not removed') })
 })
 
+test('in-flight message delivered after close does not crash the process', async t => {
+  t.plan(1)
+  // Models an emitter with asynchronous delivery (e.g. mqemitter-redis): a
+  // message already read from the network is still delivered to listeners
+  // that were matched before removeListener ran.
+  const listeners = new Map()
+  const emitter = {
+    on (topic, listener, done) {
+      listeners.set(listener, topic)
+      done()
+    },
+    removeListener (topic, listener) {
+      listeners.delete(listener)
+    },
+    emit (event, cb) {
+      const matched = [...listeners.keys()]
+      setImmediate(() => {
+        for (const listener of matched) {
+          listener(event, () => {})
+        }
+        cb()
+      })
+    }
+  }
+
+  const pubsub = new PubSub(emitter)
+  const sc = new SubscriptionContext({ pubsub })
+
+  await sc.subscribe('TOPIC')
+
+  // The message is in flight before the client goes away...
+  const delivered = new Promise(resolve => {
+    emitter.emit({ topic: 'TOPIC', payload: 1 }, resolve)
+  })
+
+  // ...and the subscription closes (queue ends) before it is delivered.
+  sc.close()
+
+  await delivered
+  t.assert.ok('in-flight message after close did not throw')
+})
+
+test('message delivered to a destroyed queue is dropped', async t => {
+  t.plan(1)
+  const pubsub = new PubSub(mq())
+  const sc = new SubscriptionContext({ pubsub })
+
+  await sc.subscribe('TOPIC')
+  sc.queue.destroy()
+
+  await sc.publish({
+    topic: 'TOPIC',
+    payload: 1
+  })
+  t.assert.ok('message to destroyed queue did not throw')
+})
+
+test('subscription queue error is logged, not fatal', t => {
+  t.plan(1)
+  const pubsub = new PubSub(mq())
+
+  const fastifyMock = {
+    log: {
+      error () {
+        t.assert.ok('error was logged')
+      }
+    }
+  }
+  const sc = new SubscriptionContext({ pubsub, fastify: fastifyMock })
+
+  sc.queue.emit('error', new Error('Dummy error'))
+})
+
 test('subscription context should not call removeListener more than one time when close called multiple times', async t => {
   const q = mq()
   const removeListener = capture(q, 'removeListener')


### PR DESCRIPTION
Fixes #1250

An emitter with asynchronous delivery (e.g. `mqemitter-redis`) can deliver a message that was already in flight when `SubscriptionContext.close()` ended the queue with `push(null)`. Pushing into the ended Readable emits an unhandled `'error'` event (`ERR_STREAM_PUSH_AFTER_EOF`), which brings down the whole server. See the linked issue for the full analysis and stack trace.

Two guards:

- the pubsub `listener` drops a message whose queue has already ended or been destroyed — the subscriber is gone, there is nothing to deliver to
- `SubscriptionContext` attaches an `'error'` handler to its queue as defence in depth, logging instead of crashing

Tests cover all three paths: in-flight message after `close()` (fails with `ERR_STREAM_PUSH_AFTER_EOF` on master), message to a destroyed queue, and the queue `'error'` handler. `lib/subscriber.js` is at 100% line/branch/function coverage; the remaining global coverage shortfall (`index.js`, `adaptive-jit.js`) is pre-existing on master.

`npm test` (lint + unit + typescript) passes. No hot-path cost worth noting: the guard is two property reads per delivery.

We have been running this fix as a production patch against 16.8.0 — the subscription churn that previously killed our API on every E2E run no longer does.
