### PR TITLE
fix: make sendError payload format respect WebSocket subprotocol

### DIFF
--- a/lib/subscription-connection.js
+++ b/lib/subscription-connection.js
@@ -445,8 +445,11 @@ module.exports = class SubscriptionConnection {
 
   sendError (err, id) {
     const convertedError = toGraphQLError(err)
-    // Graphql over websocket spec requires that errors are wrapped in an array
-    this.sendMessage(this.protocolMessageTypes.GQL_ERROR, id, [convertedError])
+    // graphql-transport-ws requires errors wrapped in an array; the legacy
+    // subscriptions-transport-ws protocol (identified as 'graphql-ws') expects
+    // a single error object instead.
+    const payload = this.socket.protocol === 'graphql-ws' ? convertedError : [convertedError]
+    this.sendMessage(this.protocolMessageTypes.GQL_ERROR, id, payload)
   }
 
   async handleConnectionInitExtension (extension) {

--- a/lib/subscription-connection.js
+++ b/lib/subscription-connection.js
@@ -8,7 +8,7 @@ const sJSON = require('secure-json-parse')
 const { MER_ERR_GQL_VALIDATION, MER_ERR_GQL_SUBSCRIPTION_FORBIDDEN, MER_ERR_GQL_SUBSCRIPTION_UNKNOWN_EXTENSION, MER_ERR_GQL_SUBSCRIPTION_INVALID_OPERATION } = require('./errors')
 const { preSubscriptionParsingHandler, onSubscriptionResolutionHandler, preSubscriptionExecutionHandler, onSubscriptionEndHandler, onSubscriptionConnectionCloseHandler, onSubscriptionConnectionErrorHandler } = require('./handlers')
 const { kSubscriptionFactory, kLoaders } = require('./symbols')
-const { getProtocolByName } = require('./subscription-protocol')
+const { getProtocolByName, GRAPHQL_WS_PROTOCOL_SIGNALS } = require('./subscription-protocol')
 const { toGraphQLError } = require('./errors')
 const queryDepth = require('./queryDepth')
 
@@ -446,9 +446,10 @@ module.exports = class SubscriptionConnection {
   sendError (err, id) {
     const convertedError = toGraphQLError(err)
     // graphql-transport-ws requires errors wrapped in an array; the legacy
-    // subscriptions-transport-ws protocol (identified as 'graphql-ws') expects
-    // a single error object instead.
-    const payload = this.socket.protocol === 'graphql-ws' ? convertedError : [convertedError]
+    // subscriptions-transport-ws protocol expects a single error object.
+    // Use the resolved protocolMessageTypes (not socket.protocol) so that the
+    // default subprotocol applies correctly when the client omits the header.
+    const payload = this.protocolMessageTypes === GRAPHQL_WS_PROTOCOL_SIGNALS ? convertedError : [convertedError]
     this.sendMessage(this.protocolMessageTypes.GQL_ERROR, id, payload)
   }
 

--- a/test/query-depth.test.js
+++ b/test/query-depth.test.js
@@ -516,5 +516,6 @@ test('queryDepth - enforce depth limit for subscriptions over websocket', async 
   const errorMessage = await waitForMessageType('error')
 
   t.assert.strictEqual(errorMessage.id, '1')
-  t.assert.match(errorMessage.payload[0].message, /Graphql validation error/)
+  // graphql-ws (subscriptions-transport-ws) sends a single error object, not an array
+  t.assert.match(errorMessage.payload.message, /Graphql validation error/)
 })

--- a/test/subscription-connection.test.js
+++ b/test/subscription-connection.test.js
@@ -943,3 +943,37 @@ test('should use default protocol when client does not specify a subprotocol', a
 
   ws.close()
 })
+
+test('sendError sends a plain object for graphql-ws protocol', async (t) => {
+  t.plan(2)
+  const messages = []
+  const sc = new SubscriptionConnection({
+    on () {},
+    close () {},
+    send (msg, cb) { messages.push(JSON.parse(msg)); cb() },
+    protocol: GRAPHQL_WS
+  }, {})
+
+  await sc.sendError(new Error('boom'), 1)
+
+  t.assert.strictEqual(messages.length, 1)
+  // legacy graphql-ws expects the payload to be a single error object, not an array
+  t.assert.ok(!Array.isArray(messages[0].payload), 'payload must not be an array for graphql-ws')
+})
+
+test('sendError wraps error in array for graphql-transport-ws protocol', async (t) => {
+  t.plan(2)
+  const messages = []
+  const sc = new SubscriptionConnection({
+    on () {},
+    close () {},
+    send (msg, cb) { messages.push(JSON.parse(msg)); cb() },
+    protocol: GRAPHQL_TRANSPORT_WS
+  }, {})
+
+  await sc.sendError(new Error('boom'), 1)
+
+  t.assert.strictEqual(messages.length, 1)
+  // graphql-transport-ws spec requires errors wrapped in an array
+  t.assert.ok(Array.isArray(messages[0].payload), 'payload must be an array for graphql-transport-ws')
+})

--- a/test/subscription-connection.test.js
+++ b/test/subscription-connection.test.js
@@ -977,3 +977,52 @@ test('sendError wraps error in array for graphql-transport-ws protocol', async (
   // graphql-transport-ws spec requires errors wrapped in an array
   t.assert.ok(Array.isArray(messages[0].payload), 'payload must be an array for graphql-transport-ws')
 })
+
+test('sendError uses the resolved subprotocol, not the raw socket.protocol header', async (t) => {
+  // A client that omits the subprotocol header (socket.protocol === '') is
+  // resolved to wsDefaultSubprotocol. sendError must use that resolved protocol
+  // to decide the payload shape — not the raw empty socket.protocol string.
+  const app = fastify()
+  t.after(() => app.close())
+
+  app.register(mercurius, {
+    schema: `
+      type Query { _placeholder: String }
+      type Subscription { onMessage: String! }
+    `,
+    resolvers: {
+      Query: {},
+      Subscription: {
+        onMessage: { async * subscribe () { yield { onMessage: 'hello' } } }
+      }
+    },
+    subscription: { wsDefaultSubprotocol: GRAPHQL_WS }
+  })
+
+  await app.listen({ port: 0 })
+  const port = app.server.address().port
+  const url = `ws://localhost:${port}/graphql`
+
+  async function errorPayload (subprotocol) {
+    const ws = subprotocol ? new WebSocket(url, subprotocol) : new WebSocket(url)
+    await once(ws, 'open')
+    ws.send(JSON.stringify({ type: 'connection_init' }))
+    ws.send(JSON.stringify({ type: 'not-a-real-message-type', id: 1 }))
+    for await (const [message] of on(ws, 'message')) {
+      const data = JSON.parse(message.toString())
+      if (data.type === 'error') {
+        ws.close()
+        return data.payload
+      }
+    }
+  }
+
+  const negotiated = await errorPayload(GRAPHQL_WS)
+  const defaulted = await errorPayload()
+
+  t.assert.strictEqual(
+    Array.isArray(negotiated),
+    Array.isArray(defaulted),
+    'a client that omits the subprotocol must receive the same error payload shape as one that negotiates it explicitly'
+  )
+})

--- a/test/subscription-hooks.test.js
+++ b/test/subscription-hooks.test.js
@@ -253,7 +253,8 @@ test('subscription - should handle preSubscriptionParsing hook errors', async t 
     t.assert.deepEqual(data, {
       id: 1,
       type: 'error',
-      payload: [{ message: 'a preSubscriptionParsing error occurred' }]
+      // graphql-ws (subscriptions-transport-ws) expects a single error object, not an array
+      payload: { message: 'a preSubscriptionParsing error occurred' }
     })
   }
 })
@@ -303,7 +304,8 @@ test('subscription - should handle preSubscriptionExecution hook errors', async 
     t.assert.deepEqual(data, {
       id: 1,
       type: 'error',
-      payload: [{ message: 'a preSubscriptionExecution error occurred' }]
+      // graphql-ws (subscriptions-transport-ws) expects a single error object, not an array
+      payload: { message: 'a preSubscriptionExecution error occurred' }
     })
   }
 })

--- a/test/subscription.test.js
+++ b/test/subscription.test.js
@@ -1317,14 +1317,15 @@ test('subscription server sends correct error if execution throws', (t, done) =>
       const data = JSON.parse(chunk)
 
       if (data.id === 1 && data.type === 'error') {
+        // graphql-ws (subscriptions-transport-ws) expects a single error object, not an array
         t.assert.strictEqual(chunk, JSON.stringify({
           type: 'error',
           id: 1,
-          payload: [{
+          payload: {
             message: 'custom execution error',
             locations: [{ line: 3, column: 13 }],
             path: ['notificationAdded']
-          }]
+          }
         }))
 
         client.end()


### PR DESCRIPTION
## Problem

`sendError` in `lib/subscription-connection.js` unconditionally wraps the error in an array:

```js
this.sendMessage(this.protocolMessageTypes.GQL_ERROR, id, [convertedError])
```

This is correct for the `graphql-transport-ws` protocol (the newer spec), but breaks clients using the legacy `subscriptions-transport-ws` protocol. In mercurius/Fastify, that legacy protocol is identified by `socket.protocol === 'graphql-ws'` — and it expects a **single** error object as the payload, not an array.

Sending an array to a `subscriptions-transport-ws` client causes the client to fail to parse the error, surfacing as an unhandled error or silent failure rather than a proper GraphQL error.

## Fix

The active subprotocol is already available on `this.socket.protocol` and is used elsewhere in the same class for protocol-branching logic. The fix is a one-line conditional:

```js
const payload = this.socket.protocol === 'graphql-ws' ? convertedError : [convertedError]
```

- `'graphql-ws'` → legacy `subscriptions-transport-ws` → single error object
- anything else (e.g. `'graphql-transport-ws'`) → newer spec → array

Closes #1132